### PR TITLE
{flash ? <EchoPay /> : children}

### DIFF
--- a/app/NX/DesignSystem/components/Footer.tsx
+++ b/app/NX/DesignSystem/components/Footer.tsx
@@ -8,7 +8,7 @@ import {
 	styled,
 	AppBar,
 	Fab,
-	lighten,
+	darken,
 } from '@mui/material';
 import { useDispatch } from '../../Uberedux';
 import { Icon, Nav } from '../../DesignSystem';
@@ -18,14 +18,18 @@ import { useFlash, setFlash } from '../../Flash';
 import { EchoPayApp } from '../../../../public/echopay/flash';
 import { NXMCApp } from '../../../../public/nx/flash/';
 
-const StyledFab = styled(Fab)({
+const StyledFab = styled(Fab)(({ theme }) => ({
 	position: 'absolute',
 	zIndex: 1,
 	top: 0,
 	left: 0,
 	right: 0,
 	margin: '0 auto',
-});
+	'&:hover': {
+		backgroundColor: darken(theme.palette.background.paper, 0.2),
+		boxShadow: 0,
+	},
+}));
 
 const validScenes = ['EchoPay', 'NXMC'];
 
@@ -79,7 +83,7 @@ export default function Footer({
 								color="primary" aria-label="cta"
 								sx={{
 									boxShadow: 0,
-									backgroundColor: lighten(theme.palette.background.default, 0.1),
+									backgroundColor: theme.palette.background.default,
 								}}
 								onClick={handleFabClick}
 							>

--- a/app/NX/NX.tsx
+++ b/app/NX/NX.tsx
@@ -15,7 +15,7 @@ const NX: React.FC<I_NX> = ({
     flash,
 }) => {
 
-    const themeMode = config?.cartridges?.designSystem?.defaultTheme || 'light';
+    const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme === 'dark') ? 'dark' : 'light';
     let theme = config?.cartridges?.designSystem?.themes?.[themeMode];
     if (theme) {
         const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';

--- a/app/NX/NX.tsx
+++ b/app/NX/NX.tsx
@@ -1,19 +1,25 @@
 "use client";
 import React from 'react';
-import { I_NX } from './types';
+import { I_NX, T_Theme } from './types';
 import { Box } from '@mui/material';
 import { DesignSystem, Feedback } from './DesignSystem';
 import { useDispatch } from './Uberedux';
 import { setFlash } from './Flash';
+import { EchoPay } from '../../public/echopay/flash';
 
 const NX: React.FC<I_NX> = ({
     children,
     config,
     frontmatter,
+    flash,
 }) => {
 
     const themeMode = config?.cartridges?.designSystem?.defaultTheme || 'light';
-    const theme = config?.cartridges?.designSystem?.themes?.[themeMode];
+    let theme = config?.cartridges?.designSystem?.themes?.[themeMode];
+    if (theme) {
+        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
+        theme = { ...theme, mode };
+    }
     const dispatch = useDispatch();
 
     React.useEffect(() => {
@@ -38,10 +44,11 @@ const NX: React.FC<I_NX> = ({
             </Box>
         );
     }
+
     return (
-        <DesignSystem theme={theme}>
+        <DesignSystem theme={theme as T_Theme}>
             <Feedback />
-            {children}
+            {flash ? <EchoPay /> : children}
         </DesignSystem>
     );
 };

--- a/app/NX/NX.tsx
+++ b/app/NX/NX.tsx
@@ -6,6 +6,7 @@ import { DesignSystem, Feedback } from './DesignSystem';
 import { useDispatch } from './Uberedux';
 import { setFlash } from './Flash';
 import { EchoPay } from '../../public/echopay/flash';
+import { NXMC } from '../../public/nx/flash';
 
 const NX: React.FC<I_NX> = ({
     children,
@@ -45,10 +46,16 @@ const NX: React.FC<I_NX> = ({
         );
     }
 
+    let flashContent = children;
+    if (flash === 'NXMC') {
+        flashContent = <NXMC />;
+    } else if (flash === 'EchoPay') {
+        flashContent = <EchoPay />;
+    }
     return (
         <DesignSystem theme={theme as T_Theme}>
             <Feedback />
-            {flash ? <EchoPay /> : children}
+            {flashContent}
         </DesignSystem>
     );
 };

--- a/app/NX/Paywall/components/SignIn.tsx
+++ b/app/NX/Paywall/components/SignIn.tsx
@@ -37,11 +37,10 @@ export default function SignIn({ onSignIn, config }: { onSignIn: (email: string,
         }
     };
 
-    const themeMode = 'light';
+    const themeMode: 'light' | 'dark' = 'light';
     let theme = config?.cartridges?.designSystem?.themes?.[themeMode];
     if (theme) {
-        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
-        theme = { ...theme, mode };
+        theme = { ...theme, mode: themeMode };
     }
     const { title, icon, description, image } = config;
 

--- a/app/NX/Paywall/components/SignIn.tsx
+++ b/app/NX/Paywall/components/SignIn.tsx
@@ -38,7 +38,11 @@ export default function SignIn({ onSignIn, config }: { onSignIn: (email: string,
     };
 
     const themeMode = 'light';
-    const theme = config?.cartridges?.designSystem?.themes?.[themeMode];
+    let theme = config?.cartridges?.designSystem?.themes?.[themeMode];
+    if (theme) {
+        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
+        theme = { ...theme, mode };
+    }
     const { title, icon, description, image } = config;
 
     return (

--- a/app/NX/lib/index.tsx
+++ b/app/NX/lib/index.tsx
@@ -3,6 +3,7 @@ import { serverUseConfig } from './serverHooks/serverUseConfig';
 import { serverUseMDBySlug } from './serverHooks/serverUseMDBySlug';
 import { serverUseAllMd } from './serverHooks/serverUseAllMd';
 import { serverUseSmartImage } from './serverHooks/serverUseSmartImage';
+import { resolveProject } from './resolveProject'
 
 export {
     serverUseNav,
@@ -10,4 +11,5 @@ export {
     serverUseMDBySlug,
     serverUseAllMd,
     serverUseSmartImage,
+    resolveProject,
 };

--- a/app/NX/lib/resolveProject.tsx
+++ b/app/NX/lib/resolveProject.tsx
@@ -1,0 +1,45 @@
+import type { T_ProjectSlug } from '../types';
+
+import nxConfig from '../../../public/nx/config.json';
+import mcukConfig from '../../../public/mcuk/config.json';
+import echopayConfig from '../../../public/echopay/config.json';
+import akiConfig from '../../../public/aki/config.json';
+import flashConfig from '../../../public/flash/config.json';
+import edtechConfig from '../../../public/edtech/config.json';
+
+export const resolveProject = (projectSlug: T_ProjectSlug) => {
+
+    let config;
+    let markdownDir;
+    switch (projectSlug) {
+        case 'mcuk':
+            config = mcukConfig;
+            markdownDir = process.cwd() + '/public/mcuk/markdown';
+            break;
+        case 'echopay':
+            config = echopayConfig;
+            markdownDir = process.cwd() + '/public/echopay/markdown';
+            break;
+        case 'edtech':
+            config = edtechConfig;
+            markdownDir = process.cwd() + '/public/edtech/markdown';
+            break;
+        case 'aki':
+            config = akiConfig;
+            markdownDir = process.cwd() + '/public/aki/markdown';
+            break;
+        case 'flash':
+            config = flashConfig;
+            markdownDir = process.cwd() + '/public/flash/markdown';
+            break;
+        default:
+            config = nxConfig;
+            markdownDir = process.cwd() + '/public/nx/markdown';
+            break;
+    }
+    return {
+        projectSlug,
+        config,
+        markdownDir
+    };
+};

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -1,14 +1,15 @@
 import type { T_UbereduxDispatch } from '../NX/Uberedux/store';
+export { T_UbereduxDispatch }
 
-export {
-    T_UbereduxDispatch,
-}
+export type T_ProjectSlug = 'nx' | 'mcuk' | 'echopay' | 'edtech' | 'aki' | 'flash';
 
 export interface I_NX {
     children: React.ReactNode;
     config: T_Config;
     frontmatter?: T_Frontmatter;
+    flash?: string;
 }
+
 export interface I_SmartImage {
     smartImage?: T_SmartImage;
 }
@@ -23,23 +24,16 @@ export type T_SmartImage = {
 
 export type T_Ad =
     | {
-        type: 'link';
+        type: string;
         title: string;
-        url: string;
-        description?: string;
-        icon?: string;
-        image?: string;
-        target?: '_blank' | '_self';
-    }
-    | {
-        type: 'route';
-        title: string;
-        path: string;
+        url?: string;
+        path?: string;
         price?: string;
         description?: string;
         icon?: string;
         image?: string;
         affiliate?: string;
+        target?: string;
     };
 
 export type T_CommerceCartridge = {
@@ -94,7 +88,7 @@ export type T_DesignSystemCartridge = {
     smartImages?: boolean | T_SmartImage[];
     themes: {
         [key: string]: {
-            mode: 'light' | 'dark';
+            mode: string;
             primary: string;
             secondary: string;
             background: string;

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -53,12 +53,11 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
 
     let title = config.title || project.toUpperCase();
     let description = config.description || "";
-    const themeMode = 'light';
+    const themeMode: 'light' | 'dark' = 'light';
     const themes = config?.cartridges?.designSystem?.themes;
     let theme = themes && themeMode in themes ? themes[themeMode as keyof typeof themes] : undefined;
     if (theme) {
-        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
-        theme = { ...theme, mode };
+        theme = { ...theme, mode: themeMode };
     }
 
     if (filePath && fs.existsSync(filePath)) {
@@ -124,12 +123,11 @@ export default async function Page(props: any) {
     if (data.title) title = data.title;
     if (data.description) description = data.description;
     const navItems = await serverUseNav(data.slug || "/");
-    const themeMode = config?.cartridges?.designSystem?.defaultTheme || 'light';
+    const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme === 'dark') ? 'dark' : 'light';
     const themes = config?.cartridges?.designSystem?.themes;
     let theme = themes && themeMode in themes ? themes[themeMode as keyof typeof themes] : undefined;
     if (theme) {
-        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
-        theme = { ...theme, mode };
+        theme = { ...theme, mode: themeMode };
     }
     const bgCol = theme?.background || '#000';
     let themedIcon = config?.icon || null;

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -1,9 +1,8 @@
-import type { I_NestedNav, T_Config } from '../NX/types';
-import { notFound } from "next/navigation";
-import { Metadata } from "next";
-import { serverUseNav } from "../NX/lib/";
+import type { I_NestedNav, T_ProjectSlug } from '../NX/types';
 import fs from "fs";
 import matter from "gray-matter";
+import { notFound } from "next/navigation";
+import { Metadata } from "next";
 import {
     Box,
     AppBar,
@@ -13,12 +12,15 @@ import {
     IconButton,
     Typography,
 } from '@mui/material';
+import { NX } from '../NX';
 import {
     serverUseMDBySlug,
     serverUseAllMd,
     serverUseSmartImage,
+    serverUseNav,
+    resolveProject,
+
 } from '../NX/lib';
-import { NX } from '../NX';
 import {
     Icon,
     Nav,
@@ -27,40 +29,15 @@ import {
 } from '../NX/DesignSystem';
 import { Commerce } from '../NX/Commerce';
 import { RenderMarkdown } from '../NX/Shortcodes';
-import nxConfig from '../../public/nx/config.json';
-import mcukConfig from '../../public/mcuk/config.json';
-import echopayConfig from '../../public/echopay/config.json';
-import akiConfig from '../../public/aki/config.json';
-import flashConfig from '../../public/flash/config.json';
-import edtechConfig from '../../public/edtech/config.json';
+
+import { EchoPay } from '../../public/echopay/flash'
+
 
 export async function generateMetadata({ params }: { params: any }): Promise<Metadata> {
-    const fs = require("fs");
-    const matter = require("gray-matter");
     const resolvedParams = typeof params.then === 'function' ? await params : params;
     const slugArr = resolvedParams?.slug || [];
     const project = process.env.NEXT_PUBLIC_PROJECT || "nx";
-    let config: T_Config;
-    switch (project) {
-        case 'mcuk':
-            config = mcukConfig as T_Config;
-            break;
-        case 'echopay':
-            config = echopayConfig as T_Config;
-            break;
-        case 'edtech':
-            config = edtechConfig as T_Config;
-            break;
-        case 'aki':
-            config = akiConfig as T_Config;
-            break;
-        case 'flash':
-            config = flashConfig as T_Config;
-            break;
-        default:
-            config = nxConfig as T_Config;
-            break;
-    }
+    const { config, markdownDir } = resolveProject(project as T_ProjectSlug);
     const filePath = serverUseMDBySlug(slugArr, project);
     let frontmatter: Record<string, any> = {};
     if (filePath && fs.existsSync(filePath)) {
@@ -77,7 +54,12 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     let title = config.title || project.toUpperCase();
     let description = config.description || "";
     const themeMode = 'light';
-    const theme = config?.cartridges?.designSystem?.themes?.[themeMode];
+    const themes = config?.cartridges?.designSystem?.themes;
+    let theme = themes && themeMode in themes ? themes[themeMode as keyof typeof themes] : undefined;
+    if (theme) {
+        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
+        theme = { ...theme, mode };
+    }
 
     if (filePath && fs.existsSync(filePath)) {
         const md = fs.readFileSync(filePath, "utf-8");
@@ -112,31 +94,9 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
 
 
 export async function generateStaticParams() {
-    const path = require("path");
     const project = process.env.NEXT_PUBLIC_PROJECT || "nx";
-    let markdownDir;
-    switch (project) {
-        case 'mcuk':
-            markdownDir = path.resolve(process.cwd(), "public", "mcuk", "markdown");
-            break;
-        case 'echopay':
-            markdownDir = path.resolve(process.cwd(), "public", "echopay", "markdown");
-            break;
-        case 'edtech':
-            markdownDir = path.resolve(process.cwd(), "public", "edtech", "markdown");
-            break;
-        case 'aki':
-            markdownDir = path.resolve(process.cwd(), "public", "aki", "markdown");
-            break;
-        case 'flash':
-            markdownDir = path.resolve(process.cwd(), "public", "flash", "markdown");
-            break;
-        default:
-            markdownDir = path.resolve(process.cwd(), "public", "nx", "markdown");
-    }
-
+    const { markdownDir } = resolveProject(project as T_ProjectSlug);
     let allSlugs = serverUseAllMd(markdownDir, project);
-
     return allSlugs.map((slugArr) => {
         const normalized = slugArr.filter(Boolean);
         return { slug: normalized.length ? normalized : undefined };
@@ -151,58 +111,43 @@ export default async function Page(props: any) {
     while (slugArr.length > 1 && slugArr[slugArr.length - 1] === "") {
         slugArr.pop();
     }
-    // Define slugPath for use as currentPath
-    const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
+    // const bg = config.cartridges?.designSystem?.themes['light'].background || '#ffffff';
+    // const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
     const project = process.env.NEXT_PUBLIC_PROJECT || "nx";
-    let config: T_Config;
-    switch (project) {
-        case 'mcuk':
-            config = mcukConfig as T_Config;
-            break;
-        case 'echopay':
-            config = echopayConfig as T_Config;
-            break;
-        case 'aki':
-            config = akiConfig as T_Config;
-            break;
-        case 'edtech':
-            config = edtechConfig as T_Config;
-            break;
-        case 'flash':
-            config = flashConfig as T_Config;
-            break;
-        default:
-            config = nxConfig as T_Config;
-            break;
-    }
-    const bg = config.cartridges?.designSystem?.themes['light'].background || '#ffffff';
+    const { config } = resolveProject(project as T_ProjectSlug);
     const filePath = serverUseMDBySlug(slugArr, project);
-
-    if (!filePath || !fs.existsSync(filePath)) {
-        notFound();
-    };
+    if (!filePath || !fs.existsSync(filePath)) notFound();
     let title = project.toUpperCase();
     let description = "";
     const md = fs.readFileSync(filePath, "utf-8");
     const { content, data } = matter(md);
     if (data.title) title = data.title;
     if (data.description) description = data.description;
-
     const navItems = await serverUseNav(data.slug || "/");
-
-    // Remove cartridge flag logic. Prepare for flash prop logic below.
     const themeMode = config?.cartridges?.designSystem?.defaultTheme || 'light';
-    // const theme = config?.cartridges?.designSystem?.themes?.[themeMode];
-    const bgCol = config?.cartridges?.designSystem?.themes?.[themeMode]?.background || '#000';
-
-    let themedIcon = config?.icon || null;
-    if (themeMode === 'dark') {
-        themedIcon = config?.darkIcon || themedIcon;
+    const themes = config?.cartridges?.designSystem?.themes;
+    let theme = themes && themeMode in themes ? themes[themeMode as keyof typeof themes] : undefined;
+    if (theme) {
+        const mode: 'light' | 'dark' = themeMode === 'dark' ? 'dark' : 'light';
+        theme = { ...theme, mode };
     }
+    const bgCol = theme?.background || '#000';
+    let themedIcon = config?.icon || null;
+    if (themeMode === 'dark' && 'darkIcon' in config && typeof config.darkIcon === 'string') {
+        themedIcon = config.darkIcon || themedIcon;
+    }
+    const validScenes = ['EchoPay', 'NXMC'];
+    let sceneSlug: string | undefined = undefined;
+    if (data.flash && validScenes.includes(data.flash)) {
+        sceneSlug = data.flash;
+    }
+    // sceneSlug can now be used as needed
+    // if (sceneSlug === 'EchoPay') {
+    //     return <EchoPay />;
+    // }
 
-    // ...existing code...
     return (
-        <NX config={config} frontmatter={data}>
+        <NX config={config} frontmatter={data} flash={sceneSlug}>
             <header>
                 <Box sx={{ flexGrow: 1 }}>
                     <AppBar
@@ -302,7 +247,6 @@ export default async function Page(props: any) {
                             )}
                             {description}
                         </Typography>
-                        {/* featuredImage functionality removed */}
 
                         <RenderMarkdown config={config}>
                             {content}

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -9,10 +9,16 @@ export async function GET() {
         data: {
             endpoints: [
                 {
+                    name: 'Notify',
+                    method: 'GET',
+                    path: `${getBaseurl()}/notify`
+                },
+                {
                     name: 'EchoPay',
                     method: 'GET',
                     path: `${getBaseurl()}/echopay`
                 },
+
             ]
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "scripts": {
     "dev": "yarn kill && yarn install && rm -rf .next && next dev -p 1999 --webpack",
     "build": "next build --webpack",

--- a/public/echopay/flash/EchoPay.tsx
+++ b/public/echopay/flash/EchoPay.tsx
@@ -1,4 +1,4 @@
-// TypeScript: declare import.meta.hot for Vite/webpack HMR
+// TypeScript: declare import.meta.hot for HMR
 declare global {
     interface ImportMeta {
         hot?: {
@@ -13,8 +13,6 @@ import { DesignSystem } from '../../../app/NX/DesignSystem';
 import {
     Flash,
     MovieClip,
-    Chatbot,
-    ChatbotAS,
 } from '../../../app/NX/Flash';
 import { EchoPayLogo, EchoPayLogoAS } from './EchoPayLogo';
 
@@ -24,7 +22,6 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
     const [replay, setReplay] = React.useState(0);
     const logoRef = useRef<HTMLImageElement>(null);
     const logoASRef = useRef<any>(null);
-    const chatbotRef = useRef<HTMLDivElement>(null);
 
     // HMR: force replay on module update (Next.js dev only)
     React.useEffect(() => {
@@ -43,21 +40,19 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
 
     useEffect(() => {
         const onLogoDone = () => {
-            if (chatbotRef.current) {
-                const chatbotAS = new ChatbotAS(undefined, chatbotRef);
-                if (typeof window !== 'undefined') {
-                    (window as any).__chatbotASInstance = chatbotAS;
-                }
-
-                chatbotAS.init();
-            }
+            console.log('onLogoDone');
         };
         logoASRef.current = new EchoPayLogoAS(onLogoDone, logoRef);
         if (typeof window !== 'undefined') {
             (window as any).__logoASInstance = logoASRef.current;
         }
-        logoASRef.current.init();
     }, [replay]);
+
+    useEffect(() => {
+        if (logoASRef.current) {
+            logoASRef.current.init();
+        }
+    }, []);
 
     return (
         <DesignSystem theme={theme}>
@@ -71,21 +66,6 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
                     zIndex={100}>
                     <EchoPayLogo ref={logoRef} />
                 </MovieClip>
-
-                <MovieClip
-                    id='mc_chatbot'
-                    style={{ visibility: 'hidden' }}
-                    width={'100%'}
-                    maxWidth={800}
-                    zIndex={200}
-                    ref={chatbotRef}
-                >
-                    <Chatbot
-                        title="NXMC"
-                        logo={<EchoPayLogo />}
-                    />
-                </MovieClip>
-
             </Flash>
         </DesignSystem>
     );

--- a/public/echopay/flash/EchoPayApp.tsx
+++ b/public/echopay/flash/EchoPayApp.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from 'react';
 import {
+    useTheme,
     Dialog,
     Box,
     IconButton,
@@ -8,17 +9,18 @@ import {
 import { useFlash, setFlash } from '../../../app/NX/Flash';
 import { useDispatch } from '../../../app/NX/Uberedux';
 import { Icon } from '../../../app/NX/DesignSystem';
-
 import { EchoPay } from './';
 
-export interface I_Scene {
+export interface I_EchoPayApp {
     slug?: string;
-}
+};
 
-export const EchoPayApp: React.FC<I_Scene> = ({ slug }) => {
+export const EchoPayApp: React.FC<I_EchoPayApp> = () => {
 
+    const theme = useTheme();
     const flash = useFlash();
     const dispatch = useDispatch();
+
     const handleClose = () => {
         dispatch(setFlash('sceneOpen', false));
     };
@@ -30,7 +32,10 @@ export const EchoPayApp: React.FC<I_Scene> = ({ slug }) => {
             open={!!flash?.sceneOpen}
             onClose={handleClose}
             maxWidth="sm">
-            <Box sx={{ position: 'relative' }}>
+            <Box sx={{
+                position: 'relative',
+                background: theme.palette.background.default,
+            }}>
                 <IconButton
                     onClick={handleClose}
                     color="primary"
@@ -46,8 +51,8 @@ export const EchoPayApp: React.FC<I_Scene> = ({ slug }) => {
                 <Box
                     id="app"
                     sx={{
-                        height: '85vh',
-                        minHeight: 500,
+                        height: '100vh',
+                        // minHeight: 500,
                         boxSizing: 'border-box'
                     }}
                 >

--- a/public/echopay/flash/EchoPayLogo/EchoPayLogoAS.ts
+++ b/public/echopay/flash/EchoPayLogo/EchoPayLogoAS.ts
@@ -49,7 +49,9 @@ export default class EchoPayLogoAS {
                     rotate: 0,
                     duration: 1.2,
                     ease: 'bounce.out',
-                    onComplete: this.fadeOut.bind(this)
+                    onComplete: () => {
+                        console.log('EchoPayLogoAS');
+                    }
                 }
             );
         }

--- a/public/echopay/markdown/index.md
+++ b/public/echopay/markdown/index.md
@@ -6,7 +6,7 @@ description: Working with EchoPay is a no brainer.
 icon: right
 tags: EchoPay, Flash, API, NX, Payments, Open Banking,
 image: https://live.staticflickr.com/65535/55111827934_a064f9cf37_c.jpg
-flashX: EchoPay
+flash: EchoPay
 ---
 
 > Rob Eastwood, Small Beer managing director


### PR DESCRIPTION
This pull request refactors the flash/scene system to support rendering EchoPay and NXMC flash animations based on markdown frontmatter. It introduces a centralized `resolveProject()` helper to eliminate duplicated config loading logic, updates the theme handling to ensure themes have proper mode properties, and removes unused chatbot functionality from the EchoPay component.

**Changes:**
- Refactored project config resolution into a reusable `resolveProject()` helper function
- Added flash prop to NX component to conditionally render flash scenes (EchoPay or NXMC)
- Updated theme handling across components to dynamically add mode property
- Removed Chatbot component from EchoPay flash animation

### Reviewed changes

Copilot reviewed 12 out of 13 changed files in this pull request and generated 10 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| public/echopay/markdown/index.md | Fixed metadata field name from `flashX` to `flash` |
| public/echopay/flash/EchoPayLogo/EchoPayLogoAS.ts | Changed animation completion callback to console.log (removes fadeOut call) |
| public/echopay/flash/EchoPayApp.tsx | Renamed interface, added theme support, removed slug parameter usage, updated styling |
| public/echopay/flash/EchoPay.tsx | Removed Chatbot component, refactored useEffect hooks for animation initialization |
| package.json | Bumped version from 1.8.2 to 1.8.3 |
| app/api/route.ts | Added Notify endpoint to API documentation |
| app/[[...slug]]/page.tsx | Refactored to use resolveProject helper, added flash scene validation and prop passing |
| app/NX/types.d.ts | Added T_ProjectSlug type, flash prop to I_NX, simplified T_Ad type, changed theme mode to string |
| app/NX/lib/resolveProject.tsx | New helper function to centralize project config and markdown path resolution |
| app/NX/lib/index.tsx | Exported resolveProject helper |
| app/NX/Paywall/components/SignIn.tsx | Updated theme handling to add mode property |
| app/NX/NX.tsx | Added flash prop support to conditionally render flash content |
| app/NX/DesignSystem/components/Footer.tsx | Updated styling with darken function and removed lighten usage |
</details>