### PR TITLE
This PR...

### DIFF
--- a/public/echopay/flash/EchoPay.tsx
+++ b/public/echopay/flash/EchoPay.tsx
@@ -44,9 +44,8 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
             <Flash id={'NXMC_flash'}>
 
                 <MovieClip
-                    border
-                    pos="bottom-right"
                     id='mc_menu'
+                    pos="bottom-left"
                     // style={{ visibility: 'hidden' }}
                     width={50}
                     height={50}

--- a/public/echopay/flash/EchoPay.tsx
+++ b/public/echopay/flash/EchoPay.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../../app/NX/Flash';
 import { Logo, LogoAS } from './Logo';
 import { CleverText, CleverTextAS } from './CleverText';
+import { MenuClip } from './MenuClip';
 
 export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
 
@@ -41,6 +42,18 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
     return (
         <DesignSystem theme={theme}>
             <Flash id={'NXMC_flash'}>
+
+                <MovieClip
+                    border
+                    pos="bottom-right"
+                    id='mc_menu'
+                    // style={{ visibility: 'hidden' }}
+                    width={50}
+                    height={50}
+                    zIndex={200}>
+                    <MenuClip />
+                </MovieClip>
+
                 <MovieClip
                     border
                     id='mc_logo'

--- a/public/echopay/flash/MenuClip/MenuClip.tsx
+++ b/public/echopay/flash/MenuClip/MenuClip.tsx
@@ -1,26 +1,92 @@
 "use client";
 import * as React from 'react';
+import type { I_Icon } from '../../../../app/NX/types';
 import {
     // useTheme,
+    Box,
     IconButton,
+    Menu,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
 } from '@mui/material';
 import { Icon } from '../../../../app/NX/DesignSystem';
+import { MenuClipAS } from './';
 
 export default function MenuClip() {
+
+    const ActionScript = React.useRef<any>(null);
+    const clipRef = React.useRef<HTMLDivElement>(null);
 
     // const theme = useTheme();
     // let color1 = theme.palette.primary.main;
 
 
-    return (
-        <>
-            <IconButton
-                onClick={() => {
+    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
 
-                }}
+    React.useEffect(() => {
+        ActionScript.current = new MenuClipAS(clipRef);
+        ActionScript.current.init();
+    }, []);
+
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleMenuClose = () => {
+        setAnchorEl(null);
+    };
+
+    // Example menu items
+    const menuItems: { icon: import('../../../../app/NX/types').I_Icon['icon']; primary: string; secondary: string }[] = [
+        {
+            icon: 'user',
+            primary: 'Profile',
+            secondary: 'View your profile',
+        },
+        {
+            icon: 'settings',
+            primary: 'Settings',
+            secondary: 'Adjust preferences',
+        },
+        {
+            icon: 'signout',
+            primary: 'Logout',
+            secondary: 'Sign out of your account',
+        },
+    ];
+
+    return (
+        <Box ref={clipRef}>
+            <IconButton
+                onClick={handleMenuOpen}
             >
                 <Icon icon="fingerprint" />
             </IconButton>
-        </>
+            <Menu
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleMenuClose}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                PaperProps={{ style: { minWidth: 240 } }}
+            >
+                <List dense>
+                    {menuItems.map((item, idx) => (
+                        <ListItemButton key={idx} onClick={handleMenuClose} alignItems="flex-start">
+                            <ListItemIcon>
+                                <Icon icon={item.icon} />
+                            </ListItemIcon>
+                            <ListItemText
+                                primary={item.primary}
+                                secondary={item.secondary}
+                            />
+                        </ListItemButton>
+                    ))}
+                </List>
+            </Menu>
+        </Box>
     );
 }

--- a/public/echopay/flash/MenuClip/MenuClip.tsx
+++ b/public/echopay/flash/MenuClip/MenuClip.tsx
@@ -1,0 +1,26 @@
+"use client";
+import * as React from 'react';
+import {
+    // useTheme,
+    IconButton,
+} from '@mui/material';
+import { Icon } from '../../../../app/NX/DesignSystem';
+
+export default function MenuClip() {
+
+    // const theme = useTheme();
+    // let color1 = theme.palette.primary.main;
+
+
+    return (
+        <>
+            <IconButton
+                onClick={() => {
+
+                }}
+            >
+                <Icon icon="fingerprint" />
+            </IconButton>
+        </>
+    );
+}

--- a/public/echopay/flash/MenuClip/MenuClipAS.ts
+++ b/public/echopay/flash/MenuClip/MenuClipAS.ts
@@ -1,0 +1,30 @@
+import { gsap } from 'gsap';
+
+export default class MenuClipAS {
+
+    private mc?: React.RefObject<any>;
+
+    constructor(mcRef?: React.RefObject<any>) {
+        this.mc = mcRef;
+    }
+
+    init(mcRef?: React.RefObject<any>) {
+        if (mcRef) this.mc = mcRef;
+        console.log('MenuClipAS');
+        const el = this.mc?.current;
+        if (el) {
+            el.style.opacity = '0';
+            el.style.visibility = 'visible';
+        }
+        this.fadeIn();
+    }
+
+    fadeIn() {
+        const el = this.mc?.current;
+        if (el) {
+            gsap.to(el, {
+                opacity: 1,
+            });
+        }
+    }
+}

--- a/public/echopay/flash/MenuClip/index.tsx
+++ b/public/echopay/flash/MenuClip/index.tsx
@@ -1,0 +1,5 @@
+import MenuClip from './MenuClip';
+
+export {
+    MenuClip
+};

--- a/public/echopay/flash/MenuClip/index.tsx
+++ b/public/echopay/flash/MenuClip/index.tsx
@@ -1,5 +1,8 @@
+
 import MenuClip from './MenuClip';
+import MenuClipAS from './MenuClipAS';
 
 export {
+    MenuClipAS,
     MenuClip
 };


### PR DESCRIPTION

Adds a new `MenuClip` MovieClip to the EchoPay Flash experience, including a small GSAP-driven intro animation and an MUI-based menu UI.

**Changes:**
- Introduces `MenuClip` React component with an `IconButton` that opens an MUI `Menu`.
- Adds `MenuClipAS` animation helper (GSAP) and re-export plumbing via `public/echopay/flash/MenuClip/index.tsx`.
- Mounts the new menu MovieClip into `public/echopay/flash/EchoPay.tsx`.

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 7 comments.

| File | Description |
| ---- | ----------- |
| public/echopay/flash/MenuClip/index.tsx | Adds barrel exports for `MenuClip` and `MenuClipAS`. |
| public/echopay/flash/MenuClip/MenuClipAS.ts | Adds GSAP-based init/fade-in behavior for the menu clip container. |
| public/echopay/flash/MenuClip/MenuClip.tsx | Adds the menu UI (IconButton + Menu/List) and initializes `MenuClipAS`. |
| public/echopay/flash/EchoPay.tsx | Renders the new `mc_menu` MovieClip containing `MenuClip`. |

Conversion of type 'string' to type 'I_Icon' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.