### PR TITLE
This PR turns on EchoPay's PayWall

### DIFF
--- a/public/echopay/config.json
+++ b/public/echopay/config.json
@@ -8,7 +8,7 @@
     "favicon": "/echopay/favicon.webp",
     "cartridges": {
         "paywall": {
-            "enabled": false,
+            "enabled": true,
             "userMode": "single",
             "email": "echopay@goldlabel.pro"
         },


### PR DESCRIPTION
## Pull request overview

This PR enables the Paywall cartridge for the `echopay` project by toggling the feature flag in the project’s public configuration.

**Changes:**
- Turned on `cartridges.paywall.enabled` for EchoPay.



