### PR TITLE
Conditionally show a Old Company

### DIFF
--- a/public/echopay/flash/EchoPay.tsx
+++ b/public/echopay/flash/EchoPay.tsx
@@ -11,24 +11,21 @@ import {
     MenuClip,
     GoViral,
 } from './';
-import { setFlash, useFlash } from '../../../app/NX/Flash';
+import { setFlash } from '../../../app/NX/Flash';
 import { useDispatch } from '../../../app/NX/Uberedux';
-import { Feedback, setFeedback } from '../../../app/NX/DesignSystem';
+import { Feedback } from '../../../app/NX/DesignSystem';
 
 export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
 
     const theme = config?.cartridges?.designSystem?.themes?.light;
     const logoRef = useRef<HTMLImageElement>(null);
     const logoASRef = useRef<any>(null);
-    const flash = useFlash();
     const dispatch = useDispatch();
-    const onDone = (flag: string | null) => {
-    };
 
     useEffect(() => {
         logoASRef.current =
-            new LogoAS(() => onDone('LogoDone'), logoRef);
-    }, [onDone]);
+            new LogoAS(() => { }, logoRef);
+    }, []);
 
     useEffect(() => {
         if (logoASRef.current) {
@@ -42,11 +39,6 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
             num: 1,
             description: 'Setup Chatbot',
         }));
-
-        // dispatch(setFeedback({
-        //     severity: 'success',
-        //     title: 'Hello!',
-        // }));
 
     }, [dispatch]);
 
@@ -63,10 +55,12 @@ export const EchoPay: React.FC<{ config?: any }> = ({ config }) => {
                     width={'95%'}
                     maxWidth={550}
                     zIndex={250}>
+
                     <NewCompany options={{
                         id: 'newcompany_mc',
                         markdown: `Why switch your card acquisition to **EchoPay**? Let's do the maths`,
                     }} />
+
                 </MovieClip>
                 <MovieClip
                     id='mc_menu'

--- a/public/echopay/flash/NewCompany/NewCompany.tsx
+++ b/public/echopay/flash/NewCompany/NewCompany.tsx
@@ -3,8 +3,6 @@ import type { I_NewCompany } from '../../types'
 import * as React from 'react';
 import { NewCompanyAS } from './';
 import {
-    darken,
-    useTheme,
     Box,
     TextField,
     Button,
@@ -13,7 +11,7 @@ import {
     Typography,
     InputAdornment,
 } from '@mui/material';
-import { CleverText, DumbText } from '../';
+import { CleverText, DumbText, OldCompany } from '../';
 import { makeMDResponse } from '../../';
 import { useFlash, setFlash } from '../../../../app/NX/Flash';
 import { useDispatch } from '../../../../app/NX/Uberedux';
@@ -21,7 +19,16 @@ import { Icon } from '../../../../app/NX/DesignSystem';
 
 export default function NewCompany({ options }: I_NewCompany) {
 
-
+    // Store slug and hasSlug in state to avoid SSR hydration mismatch
+    const [hasSlug, setHasSlug] = React.useState(false);
+    const [slug, setSlug] = React.useState<string | null>(null);
+    React.useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const params = new URLSearchParams(window.location.search);
+            setHasSlug(params.has('s'));
+            setSlug(params.get('s'));
+        }
+    }, []);
 
     const nameInputRef = React.useRef<HTMLInputElement>(null);
     const [response, setResponse] = React.useState("thinking...");
@@ -50,7 +57,6 @@ export default function NewCompany({ options }: I_NewCompany) {
 
     const ActionScript = React.useRef<any>(null);
     const clipRef = React.useRef<HTMLDivElement>(null);
-    const theme = useTheme();
     const flash = useFlash();
     const dispatch = useDispatch();
     const thisStep = flash.thisStep;
@@ -93,7 +99,7 @@ export default function NewCompany({ options }: I_NewCompany) {
     }
 
     const nextStep = () => {
-        if (thisStep.num === 1) {
+        if (thisStep?.num === 1) {
             setTimeout(() => {
                 dispatch(setFlash('thisStep', {
                     num: 2,
@@ -107,7 +113,7 @@ export default function NewCompany({ options }: I_NewCompany) {
 
             }, 2000);
         }
-        if (thisStep.num === 2) {
+        if (thisStep?.num === 2) {
             dispatch(setFlash('thisStep', {
                 num: 3,
                 description: 'Close fields and reveal response',
@@ -122,7 +128,7 @@ export default function NewCompany({ options }: I_NewCompany) {
             })
             setResponse(mdResponse);
         };
-        if (thisStep.num === 3) {
+        if (thisStep?.num === 3) {
             dispatch(setFlash('thisStep', {
                 num: 4,
                 description: 'Play response animation',
@@ -130,7 +136,7 @@ export default function NewCompany({ options }: I_NewCompany) {
 
         };
 
-        if (thisStep.num === 4) {
+        if (thisStep?.num === 4) {
             dispatch(setFlash('thisStep', {
                 num: 5,
                 description: 'Go viral',
@@ -148,23 +154,21 @@ export default function NewCompany({ options }: I_NewCompany) {
         }
     }, [thisStep]);
 
+    if (hasSlug) {
+        return <>dsalndl</>
+    }
+
     if (!thisStep) return null;
 
     return (
-        <Box
-            id={mergedOptions.id}
-        >
-            <Box ref={clipRef} sx={{
-                // border: `1px solid ${darken(theme.palette.divider, 0.9)}`,
-                // bgcolor: darken(theme.palette.background.paper, 0.25),
-                // borderRadius: 2,
-                px: 1,
-            }}>
+        <Box id={mergedOptions.id}>
+
+            <Box ref={clipRef}>
 
                 {/* <pre>flash: {JSON.stringify(flash, null, 2)}</pre> */}
 
                 {/* Step 1: Intro CleverText (show in step 1 and 2) */}
-                <Collapse in={thisStep.num === 1 || thisStep.num === 2}>
+                <Collapse in={thisStep?.num === 1 || thisStep?.num === 2}>
                     <CleverText options={{
                         id: '',
                         markdown: mergedOptions.markdown,
@@ -173,7 +177,7 @@ export default function NewCompany({ options }: I_NewCompany) {
                 </Collapse>
 
                 {/* Step 2: Form fields */}
-                <Collapse in={thisStep.num === 2}>
+                <Collapse in={thisStep?.num === 2}>
                     <Box id="newcompany_mc" sx={{ px: 2 }} onKeyDown={handleKeyDown}>
 
                         <Box sx={{ display: 'flex', my: 2, }}>
@@ -241,10 +245,11 @@ export default function NewCompany({ options }: I_NewCompany) {
 
                         <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
                             <Box sx={{}}>
-                                <Typography variant="body2" sx={{}} >
+                                <Typography variant="caption"  >
                                     Business card ratio ({Number(fields.biz)}%)
                                 </Typography>
                                 <Slider
+                                    sx={{ mt: 1 }}
                                     value={Number(fields.biz)}
                                     min={0}
                                     max={100}
@@ -279,9 +284,9 @@ export default function NewCompany({ options }: I_NewCompany) {
                 </Collapse>
 
                 {/* Step 3: Response CleverText */}
-                <Collapse in={thisStep.num === 3}>
+                <Collapse in={thisStep?.num === 3}>
                     <Box sx={{ px: 1 }}>
-                        {thisStep.num === 3 ? <CleverText
+                        {thisStep?.num === 3 ? <CleverText
                             options={{
                                 id: 'response_mc',
                                 markdown: response,
@@ -293,7 +298,7 @@ export default function NewCompany({ options }: I_NewCompany) {
 
 
                 {/* /* Step 4: Spread Virus */}
-                <Collapse in={thisStep.num === 4}>
+                <Collapse in={thisStep?.num === 4}>
                     <Box sx={{ p: 1, }}>
                         <DumbText
                             options={{

--- a/public/echopay/flash/OldCompany/OldCompany.tsx
+++ b/public/echopay/flash/OldCompany/OldCompany.tsx
@@ -1,0 +1,15 @@
+"use client";
+import type { I_OldCompany } from '../../types'
+import * as React from 'react';
+import {
+    Box,
+} from '@mui/material';
+
+export default function OldCompany({ options }: I_OldCompany) {
+
+    return (
+        <Box>
+            Load old Old Company by slug {options?.slug}
+        </Box >
+    );
+}

--- a/public/echopay/flash/OldCompany/OldCompanyAS.ts
+++ b/public/echopay/flash/OldCompany/OldCompanyAS.ts
@@ -1,0 +1,33 @@
+import { gsap } from 'gsap';
+
+export default class NewCompanyAS {
+    private mc?: React.RefObject<any>;
+
+    constructor(mcRef?: React.RefObject<any>) {
+        this.mc = mcRef;
+    }
+
+    init() {
+        // console.log('NewCompany init');
+        const el = this.mc?.current;
+        if (el) {
+            el.style.opacity = '0';
+            el.style.visibility = 'visible';
+        }
+        this.fadeIn();
+    }
+
+    fadeIn() {
+        // console.log('NewCompany fadeIn');
+        const el = this.mc?.current;
+        if (el) {
+            gsap.to(el, {
+                opacity: 1,
+                duration: 2,
+                ease: 'expo.out'
+            });
+        }
+    }
+
+
+}

--- a/public/echopay/flash/OldCompany/index.tsx
+++ b/public/echopay/flash/OldCompany/index.tsx
@@ -1,0 +1,7 @@
+import OldCompany from './OldCompany';
+import OldCompanyAS from './OldCompanyAS';
+
+export {
+    OldCompany,
+    OldCompanyAS,
+};

--- a/public/echopay/flash/index.tsx
+++ b/public/echopay/flash/index.tsx
@@ -7,6 +7,7 @@ import { CleverText } from './CleverText';
 import { DumbText } from './DumbText';
 import { RequiredText } from './RequiredText';
 import { NewCompany } from './NewCompany';
+import { OldCompany } from './OldCompany';
 import { GoViral } from './GoViral';
 
 export {
@@ -18,6 +19,7 @@ export {
     DumbText,
     RequiredText,
     NewCompany,
+    OldCompany,
     MenuClip,
     GoViral,
 };

--- a/public/echopay/types.d.ts
+++ b/public/echopay/types.d.ts
@@ -1,8 +1,13 @@
-export interface I_NewCompanyOptions {
+export interface I_CompanyOptions {
     id?: string;
+    slug?: string;
     markdown?: string;
 }
 
 export interface I_NewCompany {
-    options?: I_NewCompanyOptions;
+    options?: I_CompanyOptions;
+}
+
+export interface I_OldCompany {
+    options?: I_CompanyOptions;
 }


### PR DESCRIPTION

Adds support for displaying an “OldCompany” experience alongside the existing “NewCompany” flow in the EchoPay flash UI, using a shared options type and wiring the new component into the flash exports.

**Changes:**
- Introduced `I_OldCompany` and a shared `I_CompanyOptions` (with `slug`) in `public/echopay/types.d.ts`.
- Added an `OldCompany` component/module and exported it from the flash barrel.
- Began adding query-param based branching in `NewCompany` to switch to an “old company” path.

### Reviewed changes

Copilot reviewed 6 out of 7 changed files in this pull request and generated 6 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| public/echopay/types.d.ts | Introduces shared options type and adds `I_OldCompany`. |
| public/echopay/flash/index.tsx | Exports `OldCompany` from the flash barrel. |
| public/echopay/flash/OldCompany/index.tsx | New barrel export for `OldCompany` and its ActionScript class. |
| public/echopay/flash/OldCompany/OldCompanyAS.ts | Adds GSAP ActionScript class for OldCompany (currently misnamed). |
| public/echopay/flash/OldCompany/OldCompany.tsx | Adds placeholder OldCompany UI rendering `options.slug`. |
| public/echopay/flash/NewCompany/NewCompany.tsx | Adds query-param detection and conditional branch intended to show OldCompany. |
| public/echopay/flash/EchoPay.tsx | Minor cleanup of unused imports/effects while still rendering NewCompany. |
</details>
