### PR TITLE
This PR updates the EchoPay “flash” flow and API to support richer share/company data

### DIFF
--- a/app/api/echopay/route.ts
+++ b/app/api/echopay/route.ts
@@ -1,19 +1,20 @@
-// goldlabel-magento-store
 import { NextResponse } from 'next/server';
 import { makeRes } from '../lib/makeRes';
 import { getFirebaseApp } from '../lib/firebase';
 import { getFirestore, collection, getDocs, addDoc } from 'firebase/firestore';
 
-export type T_EchoPayExample = {
+export type T_EchoPayRoute = {
     name: string, // Company name
     slug: string, // Unique identifier, e.g. "company-xyz"
     cto: number, // Card Turnover
     atv: number, // Average Transaction Value
     biz: number, // Business Card Percentage
+    markdown: string, // Optional markdown description
 }
 
 export async function GET(req: Request) {
     try {
+        // goldlabel-magento-store
         const url = new URL(req.url);
         // Get the first query param key (if any)
         const queryKeys = Array.from(url.searchParams.keys());
@@ -25,7 +26,7 @@ export async function GET(req: Request) {
             const slug = queryKeys[0];
             // Fetch all companies and find the one with the matching slug
             const snapshot = await getDocs(companiesCol);
-            const companies = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as T_EchoPayExample) }));
+            const companies = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as T_EchoPayRoute) }));
             const match = companies.find(company => company.slug === slug);
             if (match) {
                 return NextResponse.json(makeRes({
@@ -47,7 +48,7 @@ export async function GET(req: Request) {
         const companies = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as T_EchoPayExample) }));
         return NextResponse.json(makeRes({
             severity: 'success',
-            message: 'Examples',
+            message: 'Lists Companies',
             data: companies,
         }));
     } catch (error) {
@@ -58,13 +59,13 @@ export async function GET(req: Request) {
     }
 }
 
-
 const fieldDescriptions: Record<string, string> = {
     name: 'Company name (string)',
     slug: 'Unique identifier, e.g. "company-xyz" (string)',
     cto: 'Card Turnover (number)',
     atv: 'Average Transaction Value (number)',
     biz: 'Business Card Percentage (number)',
+    markdown: 'Markdown (string)',
 };
 
 function getMissingOrInvalidFields(obj: any): string[] {
@@ -97,13 +98,13 @@ export async function POST(req: Request) {
         const docRef = await addDoc(companiesCol, companyWithTime);
         return NextResponse.json(makeRes({
             severity: 'success',
-            message: 'Example added',
+            message: 'Company added',
             data: { id: docRef.id, ...companyWithTime },
         }), { status: 201 });
     } catch (error) {
         return NextResponse.json(makeRes({
             severity: 'error',
-            message: 'Failed to add Example: ' + (error instanceof Error ? error.message : String(error)),
+            message: 'Failed to add Company: ' + (error instanceof Error ? error.message : String(error)),
         }), { status: 500 });
     }
 }

--- a/app/api/echopay/route.ts
+++ b/app/api/echopay/route.ts
@@ -45,7 +45,7 @@ export async function GET(req: Request) {
 
         // Default: return all companies
         const snapshot = await getDocs(companiesCol);
-        const companies = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as T_EchoPayExample) }));
+        const companies = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as T_EchoPayRoute) }));
         return NextResponse.json(makeRes({
             severity: 'success',
             message: 'Lists Companies',

--- a/public/echopay/flash/GoViral/GoViral.tsx
+++ b/public/echopay/flash/GoViral/GoViral.tsx
@@ -15,11 +15,12 @@ import {
     DialogActions,
     Button,
     IconButton,
+    Typography,
 } from '@mui/material';
 import { useFlash, setFlash } from '../../../../app/NX/Flash';
 import { Icon } from '../../../../app/NX/DesignSystem';
 import { useDispatch } from '../../../../app/NX/Uberedux';
-import { makeMDResponse } from '../../';
+import { makeMDResponse, calculateEchoPayProfit } from '../../';
 import { defaultCompany } from '../NewCompany/NewCompany';
 
 const slugify = (text: string) => {
@@ -47,6 +48,11 @@ export default function GoViral() {
     const description = "Do the maths";
     const isMobile = require('@mui/material/useMediaQuery').default('(max-width:899.95px)');
     const slug = slugify(flash?.name ?? defaultCompany.name);
+    const profit = calculateEchoPayProfit({
+        biz: flash?.biz ?? defaultCompany.biz,
+        cto: flash?.cto ?? defaultCompany.cto,
+        atv: flash?.atv ?? defaultCompany.atv,
+    });
     const company = {
         biz: flash?.biz ?? defaultCompany.biz,
         atv: flash?.atv ?? defaultCompany.atv,
@@ -76,6 +82,7 @@ export default function GoViral() {
             <Dialog
                 open={goViralOpen}
                 fullScreen={isMobile}
+
                 fullWidth={true}
                 maxWidth="xs"
                 onClose={handleClose}
@@ -134,7 +141,12 @@ export default function GoViral() {
 
 
                     </Box>
-                    <pre>company: {JSON.stringify(company, null, 2)}</pre>
+                    {/* <Box sx={{ my: 2 }}>
+                        <Typography variant="body1">
+                            Card acquisition cost/month <span style={{ fontWeight: 'bold' }}>£{profit.currentCostPerMonth}</span>. With EchoPay? <span style={{ fontWeight: 'bold' }}>£{profit.echoPayCostPerMonth}</span>.
+                        </Typography>
+                    </Box> */}
+                    <pre>url: {JSON.stringify(url, null, 2)}</pre>
                 </DialogContent>
                 <DialogActions>
                     <Button

--- a/public/echopay/flash/GoViral/GoViral.tsx
+++ b/public/echopay/flash/GoViral/GoViral.tsx
@@ -10,19 +10,28 @@ import {
 import {
     Box,
     Dialog,
-    CardHeader,
     DialogTitle,
     DialogContent,
     DialogActions,
     Button,
-    Typography,
-    MenuItem,
-    ListItemIcon,
-    ListItemText,
+    IconButton,
 } from '@mui/material';
 import { useFlash, setFlash } from '../../../../app/NX/Flash';
 import { Icon } from '../../../../app/NX/DesignSystem';
 import { useDispatch } from '../../../../app/NX/Uberedux';
+import { makeMDResponse } from '../../';
+import { defaultCompany } from '../NewCompany/NewCompany';
+
+const slugify = (text: string) => {
+    return text
+        .toString()
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036F]/g, '') // Remove diacritics
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-') // Replace non-alphanumeric with hyphens
+        .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+}
 
 export default function GoViral() {
 
@@ -37,6 +46,21 @@ export default function GoViral() {
     const title = "EchoPay";
     const description = "Do the maths";
     const isMobile = require('@mui/material/useMediaQuery').default('(max-width:899.95px)');
+    const slug = slugify(flash?.name ?? defaultCompany.name);
+    const company = {
+        biz: flash?.biz ?? defaultCompany.biz,
+        atv: flash?.atv ?? defaultCompany.atv,
+        cto: flash?.cto ?? defaultCompany.cto,
+        name: flash?.name ?? defaultCompany.name,
+        slug,
+        markdown: makeMDResponse({
+            name: flash?.name ?? defaultCompany.name,
+            biz: flash?.biz ?? defaultCompany.biz,
+            cto: flash?.cto ?? defaultCompany.cto,
+            atv: flash?.atv ?? defaultCompany.atv,
+        }),
+        url: `/share/${slug}`
+    };
 
     React.useEffect(() => {
         ActionScript.current = new GoViralAS(clipRef);
@@ -58,87 +82,59 @@ export default function GoViral() {
                 aria-labelledby="go-viral-dialog-title"
             >
                 <DialogTitle id="go-viral-dialog-title">
-                    Send it to: Enter name
-                    email address or phone number
+
                 </DialogTitle>
+
                 <DialogContent>
-                    {/* <pre>url: {JSON.stringify(url, null, 2)}</pre> */}
+                    <Box sx={{ display: 'flex' }}>
 
-                    <MenuItem
-                        onClick={() => {
-                            navigator.clipboard.writeText(url);
-                            setCopied(true);
-                            setTimeout(() => {
-                                setCopied(false);
-                            }, 1500);
-                        }}
-                    >
-                        <ListItemIcon sx={{ mr: 1 }}>
+                        <IconButton
+                            onClick={() => {
+                                navigator.clipboard.writeText(url);
+                                setCopied(true);
+                                setTimeout(() => {
+                                    setCopied(false);
+                                }, 1500);
+                            }}
+                        >
                             <Icon icon="copy" color="primary" />
-                        </ListItemIcon>
-                        <ListItemText
-                            primary={copied ? 'Copied!' : 'Copy Link'}
-                        />
-                    </MenuItem>
+                        </IconButton>
+
+                        <Box sx={{ ml: 0, mt: 1 }}>
+                            <TwitterShareButton title={title} url={url}>
+                                <Icon icon="twitter" color="primary" />
+                            </TwitterShareButton>
+                        </Box>
+                        <Box sx={{ ml: 1, mt: 1 }}>
+                            <FacebookShareButton url={url} style={fullWidth}>
+                                <Icon icon="facebook" color="primary" />
+                            </FacebookShareButton>
+                        </Box>
+                        <Box sx={{ ml: 1, mt: 1 }}>
+                            <LinkedinShareButton
+                                url={url}
+                                title={title}
+                                summary={description}
+                                source="Goldlabel"
+                                style={fullWidth}
+                            >
+                                <Icon icon="linkedin" color="primary" />
+                            </LinkedinShareButton>
+                        </Box>
+                        <Box sx={{ ml: 1, mt: 1 }}>
+                            <WhatsappShareButton
+                                url={url}
+                                title={title}
+                                separator=" - "
+                                style={fullWidth}
+                            >
+                                <Icon icon="whatsapp" color="primary" />
+                            </WhatsappShareButton>
+                        </Box>
 
 
-                    <MenuItem sx={{ p: 0 }}>
-                        <TwitterShareButton title={title} url={url}>
-                            <Box display="flex" alignItems="center" px={2} py={1}>
-                                <ListItemIcon sx={{ mr: 1 }}>
-                                    <Icon icon="twitter" color="primary" />
-                                </ListItemIcon>
-                                <ListItemText primary="Twitter (X)" />
-                            </Box>
-                        </TwitterShareButton>
-                    </MenuItem>
-
-
-                    <MenuItem sx={{ p: 0 }}>
-                        <FacebookShareButton url={url} style={fullWidth}>
-                            <Box display="flex" alignItems="center" px={2} py={1}>
-                                <ListItemIcon sx={{ mr: 1 }}>
-                                    <Icon icon="facebook" color="primary" />
-                                </ListItemIcon>
-                                <ListItemText primary="Facebook" />
-                            </Box>
-                        </FacebookShareButton>
-                    </MenuItem>
-
-
-                    <MenuItem sx={{ p: 0 }}>
-                        <LinkedinShareButton
-                            url={url}
-                            title={title}
-                            summary={description}
-                            source="Goldlabel"
-                            style={fullWidth}
-                        >
-                            <Box display="flex" alignItems="center" px={2} py={1}>
-                                <ListItemIcon sx={{ mr: 1 }}>
-                                    <Icon icon="linkedin" color="primary" />
-                                </ListItemIcon>
-                                <ListItemText primary="LinkedIn" />
-                            </Box>
-                        </LinkedinShareButton>
-                    </MenuItem>
-
-                    <MenuItem sx={{ p: 0 }}>
-                        <WhatsappShareButton
-                            url={url}
-                            title={title}
-                            separator=" - "
-                            style={fullWidth}
-                        >
-                            <Box display="flex" alignItems="center" px={2} py={1}>
-                                <ListItemIcon sx={{ mr: 1 }}>
-                                    <Icon icon="whatsapp" color="primary" />
-                                </ListItemIcon>
-                                <ListItemText primary="WhatsApp" />
-                            </Box>
-                        </WhatsappShareButton>
-                    </MenuItem>
-
+                    </Box>
+                    <pre>company: {JSON.stringify(company, null, 2)}</pre>
                 </DialogContent>
                 <DialogActions>
                     <Button

--- a/public/echopay/flash/Logo/LogoAS.ts
+++ b/public/echopay/flash/Logo/LogoAS.ts
@@ -16,6 +16,7 @@ export default class LogoAS {
             el.style.visibility = 'visible';
             el.style.transform = 'scaleY(0)';
             el.style.transform = 'scaleX(0)';
+
             this.fadeIn();
         }
     }
@@ -48,7 +49,8 @@ export default class LogoAS {
             scale: 1,
             duration: 0.7,
             stagger: 0.12,
-            ease: 'power3.out'
+            ease: 'power3.out',
+
         });
     }
 
@@ -64,8 +66,8 @@ export default class LogoAS {
                 },
                 {
                     opacity: 1,
-                    scaleX: 1,
-                    scaleY: 1,
+                    scaleX: 0.75,
+                    scaleY: 0.75,
                     duration: 1,
                     ease: 'expo.out',
                     onComplete: () => {

--- a/public/echopay/flash/NewCompany/NewCompany.tsx
+++ b/public/echopay/flash/NewCompany/NewCompany.tsx
@@ -59,12 +59,12 @@ export default function NewCompany({ options }: I_NewCompany) {
         }
     }, [flash, dispatch]);
 
-    /*
-        Current cost/month: £X
-        Costs using EchoPay £Y
-    */
-    const costCurrent = 1500;
-    const costEchoPay = 1000;
+    // Calculate costs using calculateEchoPayProfit
+    const { currentCostPerMonth, echoPayCostPerMonth } = require('../../lib/calculateEchoPayProfit').default({
+        cto: parseFloat(fields.cto),
+        atv: parseFloat(fields.atv),
+        biz: parseFloat(fields.biz),
+    });
 
 
     const handleShare = () => {
@@ -172,7 +172,7 @@ export default function NewCompany({ options }: I_NewCompany) {
 
                         <Grid container spacing={2} sx={{ px: 2, mt: 1 }}>
                             <Grid size={{ xs: 6 }}>
-                                <Box sx={{ mx: 1 }}>
+                                <Box sx={{ mx: 0 }}>
                                     <TextField
                                         fullWidth
                                         label="Company"
@@ -191,7 +191,7 @@ export default function NewCompany({ options }: I_NewCompany) {
                                 </Box>
                             </Grid>
                             <Grid size={{ xs: 6 }}>
-                                <Box sx={{ mx: 1 }}>
+                                <Box sx={{ mx: 0 }}>
                                     <Typography variant="caption"  >
                                         Card ratio ({Number(fields.biz)}%)
                                     </Typography>
@@ -213,7 +213,7 @@ export default function NewCompany({ options }: I_NewCompany) {
                             </Grid>
 
                             <Grid size={{ xs: 6 }}>
-                                <Box sx={{ mx: 1 }}>
+                                <Box sx={{ mx: 0 }}>
                                     <TextField
                                         id="input_cto"
                                         label="Card Turnover"
@@ -236,7 +236,7 @@ export default function NewCompany({ options }: I_NewCompany) {
                             </Grid>
 
                             <Grid size={{ xs: 6 }}>
-                                <Box sx={{ mx: 1 }}>
+                                <Box sx={{ mx: 0 }}>
                                     <TextField
                                         id="input_atv"
                                         label="Average Transaction"
@@ -261,7 +261,7 @@ export default function NewCompany({ options }: I_NewCompany) {
                             <Grid size={{ xs: 12 }}>
                                 <Box sx={{ my: 2 }}>
                                     <Typography variant="body1"  >
-                                        Card acquisition cost/month <span style={{ fontWeight: 'bold' }}>£{costCurrent}</span>. With EchoPay? <span style={{ fontWeight: 'bold' }}>£{costEchoPay}</span>.
+                                        Card acquisition cost/month <span style={{ fontWeight: 'bold' }}>£{currentCostPerMonth}</span>. With EchoPay? <span style={{ fontWeight: 'bold' }}>£{echoPayCostPerMonth}</span>.
                                     </Typography>
                                 </Box>
                             </Grid>

--- a/public/echopay/flash/NewCompany/NewCompany.tsx
+++ b/public/echopay/flash/NewCompany/NewCompany.tsx
@@ -23,6 +23,7 @@ export const defaultCompany = {
     biz: '75',
     cto: '1000000',
     atv: '500',
+    markdown: `## Example Markdown`
 };
 
 export default function NewCompany({ options }: I_NewCompany) {
@@ -41,6 +42,22 @@ export default function NewCompany({ options }: I_NewCompany) {
     const clipRef = React.useRef<HTMLDivElement>(null);
     const flash = useFlash();
     const thisStep = flash.thisStep;
+
+    // Set default values in flash redux if they don't exist
+    React.useEffect(() => {
+        if (!flash.name) {
+            dispatch(setFlash('name', defaultCompany.name));
+        }
+        if (!flash.biz) {
+            dispatch(setFlash('biz', defaultCompany.biz));
+        }
+        if (!flash.cto) {
+            dispatch(setFlash('cto', defaultCompany.cto));
+        }
+        if (!flash.atv) {
+            dispatch(setFlash('atv', defaultCompany.atv));
+        }
+    }, [flash, dispatch]);
 
     /*
         Current cost/month: £X

--- a/public/echopay/flash/NewCompany/NewCompany.tsx
+++ b/public/echopay/flash/NewCompany/NewCompany.tsx
@@ -115,19 +115,7 @@ export default function NewCompany({ options }: I_NewCompany) {
             })
             setResponse(mdResponse);
         };
-        if (thisStep?.num === 3) {
-            dispatch(setFlash('thisStep', {
-                num: 4,
-                description: 'Play response animation',
-            }));
-        };
 
-        if (thisStep?.num === 4) {
-            dispatch(setFlash('thisStep', {
-                num: 5,
-                description: 'Go viral',
-            }));
-        };
     }
 
     React.useEffect(() => {
@@ -294,7 +282,30 @@ export default function NewCompany({ options }: I_NewCompany) {
 
                 {/* Step 3: Response CleverText */}
                 <Collapse in={thisStep?.num === 3}>
-                    <Box sx={{ px: 1 }}>
+
+                    <Box sx={{ display: 'flex', gap: 2 }}>
+                        <Button
+                            startIcon={<Icon icon="left" />}
+                            variant='contained'
+                            color="secondary"
+                            onClick={handleBack}
+                            sx={{ px: 3 }}
+                        >
+                            Back
+                        </Button>
+
+                        <Button
+                            fullWidth
+                            variant='contained'
+                            color="secondary"
+                            onClick={handleShare}
+                            startIcon={<Icon icon="share" />}
+                        >
+                            Share
+                        </Button>
+                    </Box>
+
+                    <Box sx={{}}>
                         {thisStep?.num === 3 ? <CleverText
                             options={{
                                 id: 'response_mc',
@@ -302,40 +313,6 @@ export default function NewCompany({ options }: I_NewCompany) {
                                 onFinish: nextStep,
                             }}
                         /> : null}
-                    </Box>
-                </Collapse>
-
-
-                {/* Step 4: Spread Virus */}
-                <Collapse in={thisStep?.num === 4}>
-                    <Box sx={{ p: 1 }}>
-                        <DumbText
-                            options={{
-                                id: 'dumbresponse_mc',
-                                markdown: response,
-                            }}
-                        />
-                        <Box sx={{ display: 'flex', gap: 2 }}>
-                            <Button
-                                startIcon={<Icon icon="left" />}
-                                variant='contained'
-                                color="secondary"
-                                onClick={handleBack}
-                                sx={{ px: 3 }}
-                            >
-                                Back
-                            </Button>
-
-                            <Button
-                                fullWidth
-                                variant='contained'
-                                color="secondary"
-                                onClick={handleShare}
-                                startIcon={<Icon icon="share" />}
-                            >
-                                Share
-                            </Button>
-                        </Box>
                     </Box>
                 </Collapse>
 


### PR DESCRIPTION
This PR updates the EchoPay “flash” flow and API to support richer share/company data (including markdown), replaces hardcoded cost figures with computed values, and tweaks sharing UI/animation behavior.

**Changes:**
- Compute and display monthly costs via `calculateEchoPayProfit` instead of hardcoded numbers in the NewCompany step.
- Refactor the “Go Viral” share dialog UI and add slug/company payload construction.
- Update the `/api/echopay` route type shape (including `markdown`) and tweak Logo animation scaling.

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 7 comments.

| File | Description |
| ---- | ----------- |
| public/echopay/flash/NewCompany/NewCompany.tsx | Adds flash default initialization and replaces hardcoded costs with calculated values; adjusts step UI. |
| public/echopay/flash/Logo/LogoAS.ts | Tweaks animation parameters (scale/ease formatting). |
| public/echopay/flash/GoViral/GoViral.tsx | Refactors share dialog UI and adds slug/company construction logic. |
| app/api/echopay/route.ts | Renames route type and adds `markdown` to the expected company payload. |


<details>
<summary>Comments suppressed due to low confidence (1)</summary>

**app/api/echopay/route.ts:82**
* `markdown` is described as optional in the comment but is required in `T_EchoPayRoute`, and it’s included in `fieldDescriptions` but never validated in `getMissingOrInvalidFields`. Align these: either make `markdown?: string` and omit it from required validation, or validate `typeof obj.markdown === 'string'` and include it in missing-field reporting.
```
export type T_EchoPayRoute = {
    name: string, // Company name
    slug: string, // Unique identifier, e.g. "company-xyz"
    cto: number, // Card Turnover
    atv: number, // Average Transaction Value
    biz: number, // Business Card Percentage
    markdown: string, // Optional markdown description
}
