### PR TITLE
This PR improves Nav

### DIFF
--- a/app/NX/DesignSystem/components/Nav.tsx
+++ b/app/NX/DesignSystem/components/Nav.tsx
@@ -52,16 +52,22 @@ const Nav: React.FC<I_Nav> = ({
         parentKey = '',
         // parentNavTarget?: string,
     ): React.ReactNode {
-        return items
-            .filter(item => {
-                const navTarget = (typeof item.slug === 'string' && item.slug.trim().length > 0)
-                    ? item.slug
-                    : (typeof (item as any).path === 'string' && (item as any).path.trim().length > 0 ? (item as any).path : undefined);
-                if (navTarget === '/') {
-                    return false;
-                }
-                return true;
-            })
+        // Always render Home button at the top
+        const homeButton = (
+            <Box key={parentKey + 'home'}>
+                <ListItemButton
+                    onClick={e => {
+                        e.preventDefault();
+                        handleNavClick('/');
+                    }}
+                    disabled={false}
+                >
+                    <ListItemText primary={'Home'} />
+                </ListItemButton>
+            </Box>
+        );
+
+        const navItems = items
             .map((item, i) => {
                 const key = `${parentKey}item_${i}`;
                 const hasChildren = Array.isArray(item.children) && item.children.length > 0;
@@ -79,6 +85,8 @@ const Nav: React.FC<I_Nav> = ({
                         return childNavTarget !== navTarget;
                     });
                 }
+                // Don't render another Home button if this item is the home link
+                if (navTarget === '/') return null;
                 return (
                     <Box key={key}>
                         <ListItemButton
@@ -99,6 +107,7 @@ const Nav: React.FC<I_Nav> = ({
                     </Box>
                 );
             });
+        return [homeButton, ...navItems.filter(Boolean)];
     }
 
 
@@ -115,18 +124,19 @@ const Nav: React.FC<I_Nav> = ({
                     anchor="right"
                     open={drawerOpen}
                     onClose={() => setDrawerOpen(false)}>
-                    <Box sx={{
-                        p: 1
-                    }}
+                    <Box
+                        sx={{ height: '100vh', display: 'flex', flexDirection: 'column', p: 1 }}
                         role="presentation"
                         onClick={() => setDrawerOpen(false)}
                     >
-                        <Virus frontmatter={frontmatter} />
-                        <Settings />
                         <List dense component={'nav'}>
                             {renderNavItems(sortedNavItems)}
                         </List>
+                        <Box sx={{ mt: 'auto' }}>
+                            <Settings />
+                            <Virus frontmatter={frontmatter} />
 
+                        </Box>
                     </Box>
                 </Drawer>
             </>

--- a/app/NX/DesignSystem/components/Nav.tsx
+++ b/app/NX/DesignSystem/components/Nav.tsx
@@ -109,8 +109,7 @@ const Nav: React.FC<I_Nav> = ({
             });
         return [homeButton, ...navItems.filter(Boolean)];
     }
-
-
+    // Removed stray slash and 'return true' lines that caused syntax error
     if (mode === 'mobile') {
         return (
             <>

--- a/app/NX/DesignSystem/components/Settings.tsx
+++ b/app/NX/DesignSystem/components/Settings.tsx
@@ -43,7 +43,7 @@ const Settings: React.FC<I_Settings> = () => {
 	if (loading) return null;
 
 	return (
-		<List dense sx={{ my: 2 }}>
+		<List dense sx={{ my: 1 }}>
 			<ListItemButton
 				id="nx-admin-button"
 				onClick={handleNXAdmin}

--- a/app/NX/Virus/Virus.tsx
+++ b/app/NX/Virus/Virus.tsx
@@ -51,7 +51,7 @@ export default function Virus({
         alignItems: 'center',
         justifyContent: 'center',
         gap: 2,
-        mt: 1
+        my: 1
       }}>
 
         <Box sx={{ mt: 0.25 }}>


### PR DESCRIPTION

Updates the NX DesignSystem navigation UI/UX, focusing on ensuring a Home entry is available and adjusting spacing/layout in mobile navigation-related components.

**Changes:**
- Prepends a “Home” entry to the nav list and skips rendering any nav item targeting `/`.
- Reworks the mobile drawer layout so Settings/Virus render at the bottom of the drawer.
- Tweaks vertical spacing in `Virus` and `Settings` components.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 3 comments.

| File | Description |
| ---- | ----------- |
| app/NX/Virus/Virus.tsx | Adjusts Virus component vertical spacing. |
| app/NX/DesignSystem/components/Settings.tsx | Reduces Settings list vertical margin. |
| app/NX/DesignSystem/components/Nav.tsx | Adds a Home button, refactors mobile drawer layout, and updates nav rendering logic. |
