### PR TITLE
Better collection

### DIFF
--- a/app/NX/NXAdmin/NXAdmin.tsx
+++ b/app/NX/NXAdmin/NXAdmin.tsx
@@ -98,6 +98,12 @@ export default function NXAdmin({
       description: 'Images, sounds, videos and PDFs etc',
       icon: 'media',
     },
+    {
+      collection: 'tenants',
+      title: 'Tenants',
+      description: 'Only level 2 users should see this',
+      icon: 'admin',
+    },
   ];
 
   // Move active collection to the front

--- a/app/NX/NXAdmin/actions/setCRUD.tsx
+++ b/app/NX/NXAdmin/actions/setCRUD.tsx
@@ -1,17 +1,26 @@
 import type { Dispatch } from 'redux';
 import { setUbereduxKey } from '../../Uberedux';
 
+/**
+ * Updates nxAdmin.crud[collection][key] with the provided value.
+ * @param collection The name of the collection to update
+ * @param key The key within the collection's CRUD object
+ * @param value The value to set for the key
+ */
 export const setCRUD = (
-    crud: any,
+    collection: string,
+    key: string,
+    value: any,
 ): any =>
     async (dispatch: Dispatch, getState: () => any) => {
         try {
-            // Get current value from state
             const state = getState();
             const current = (state?.redux?.nxAdmin) || {};
-            // Set the crud key to the incoming crud value
+            const crud = { ...current.crud };
+            const collectionCrud = { ...(crud[collection] || {}) };
+            collectionCrud[key] = value;
+            crud[collection] = collectionCrud;
             const updated = { ...current, crud };
-            // Set the updated object in Uberedux
             dispatch(setUbereduxKey({ key: 'nxAdmin', value: updated }));
         } catch (e: unknown) {
             const msg = e instanceof Error ? e.message : String(e);

--- a/app/NX/NXAdmin/components/CRUD/CreateDoc.tsx
+++ b/app/NX/NXAdmin/components/CRUD/CreateDoc.tsx
@@ -15,7 +15,7 @@ export default function CreateDoc({ collection }: I_CreateDoc) {
   return (
     <>
       <Card>
-        UpdateDoc
+        Create New Doc in {collection}
       </Card>
     </>
   );

--- a/app/NX/NXAdmin/components/Collection/Collection.tsx
+++ b/app/NX/NXAdmin/components/Collection/Collection.tsx
@@ -4,9 +4,8 @@ import {
   Card,
   Tooltip,
   CardHeader,
-  ButtonBase,
+  Button,
   CardContent,
-  Typography,
   IconButton,
 } from '@mui/material';
 import { Icon } from '../../../DesignSystem';
@@ -16,6 +15,8 @@ import {
   useActive,
   setNXAdmin,
   ReadDoc,
+  CreateDoc,
+  setCRUD,
 } from '../../../NXAdmin'
 import { useDispatch } from '../../../Uberedux'
 
@@ -52,6 +53,12 @@ export default function Collection({
     dispatch(setNXAdmin('active', collection));
   };
 
+  const handleNew = (collection: string) => {
+    console.log('New Doc in', collection);
+    // Set CRUD status for this collection to 'create'
+    dispatch(setCRUD(collection, 'mode', 'create'));
+  };
+
   if (!isActive) return <>
     <Tooltip title={title} placement="right">
       <IconButton onClick={() => activate(collection)}>
@@ -64,6 +71,13 @@ export default function Collection({
     <>
       <Card variant="outlined">
         <CardHeader
+          action={<Button
+            endIcon={<Icon icon="new" />}
+            variant="contained"
+            onClick={() => handleNew(collection)}
+          >
+            New
+          </Button>}
           title={title}
           subheader={description}
           avatar={<Icon icon={icon as any} color="primary" />}
@@ -76,20 +90,18 @@ export default function Collection({
             },
           }}
         />
-        {isActive && <>
 
 
-          {mode === 'read' && <ReadDoc collection={collection} />}
-
-          <CardContent>
+        <CardContent>
+          {/* <pre>mode: {JSON.stringify(mode, null, 2)}</pre> */}
+          {isActive && <>
+            {mode === 'read' && <ReadDoc collection={collection} />}
+            {mode === 'create' && <CreateDoc collection={collection} />}
             {/* <Typography variant="body1" color="text.secondary">
               {description}
             </Typography> */}
-          </CardContent>
-        </>}
-
-
-
+          </>}
+        </CardContent>
       </Card>
     </>
   );
@@ -103,7 +115,7 @@ export default function Collection({
   UpdateDoc,
   DeleteDoc,
 
-<pre>label: {JSON.stringify(label, null, 2)}</pre> 
+
 <pre>mode: {JSON.stringify(mode, null, 2)}</pre>
     {/* action={
       <>


### PR DESCRIPTION
PR Overview
Adds “create” flow entry points to NXAdmin collections by introducing a New button that switches a collection into create mode and renders the CreateDoc UI, plus adds a new “tenants” collection to the NXAdmin sidebar.

Changes:

Add “New” button to Collection and render CreateDoc when CRUD mode is create
Refactor setCRUD action to update nxAdmin.crud[collection][key] in state
Add tenants collection entry to the NXAdmin collections list