### PR TITLE
Typed & ready

### DIFF
--- a/app/NX/DesignSystem/components/Footer.tsx
+++ b/app/NX/DesignSystem/components/Footer.tsx
@@ -49,9 +49,7 @@ export default function Footer({
 				<Toolbar>
 					<Box sx={{ flexGrow: 1 }} />
 					<Box sx={{ display: 'flex', }}>
-						<Box sx={{ my: 2 }}>
-							<SettingsMenu />
-						</Box>
+						
 						<Box sx={{ my: 2 }}>
 							<Nav
 								mode="mobile"
@@ -59,7 +57,9 @@ export default function Footer({
 								frontmatter={frontmatter}
 							/>
 						</Box>
-						
+						<Box sx={{ my: 2 }}>
+							<SettingsMenu />
+						</Box>
 					</Box>
 					{children && (
 						<Box sx={{ ml: 2 }}>

--- a/app/NX/DesignSystem/components/SettingsMenu.tsx
+++ b/app/NX/DesignSystem/components/SettingsMenu.tsx
@@ -67,7 +67,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ config }) => {
                     </ListItemIcon>
                     <ListItemText
                         primary={<Typography>
-                            {currentThemeMode === 'light' ? 'Dark' : 'Light'}
+                            {currentThemeMode === 'light' ? 'Dark' : 'Light'} mode
                         </Typography>}
                     />
                 </ListItemButton>

--- a/app/NX/DesignSystem/components/ThemedIcon.tsx
+++ b/app/NX/DesignSystem/components/ThemedIcon.tsx
@@ -1,7 +1,6 @@
 'use client';
 import React from "react";
 import {
-    IconButton,
     Avatar,
 } from '@mui/material';
 import { useDesignSystem } from '../../DesignSystem';
@@ -26,23 +25,12 @@ const ThemedIcon: React.FC<ThemedIconProps> = ({ config }) => {
         setAvatarSrc(src);
     }, [designSystem?.themeMode, config]);
 
-    const router = require('next/navigation').useRouter();
-    const handleClick = () => {
-        router.push('/');
-    };
-
     if (!mounted) return null;
 
     return (
-        <IconButton
-            edge="start"
-            color="inherit"
-            aria-label={'Home'}
-            onClick={handleClick}>
             <Avatar
                 src={avatarSrc}
             />
-        </IconButton>
     );
 };
 

--- a/app/NX/Paywall/components/SignIn.tsx
+++ b/app/NX/Paywall/components/SignIn.tsx
@@ -112,7 +112,7 @@ export default function SignIn({ onSignIn, config, error: externalError }: SignI
                                 ),
                             }}
                         />
-                        {(error || externalError) && <Typography color="error">{error || externalError}</Typography>}
+                        
                     </CardContent>
                     <CardActions>
                         <Button
@@ -133,7 +133,9 @@ export default function SignIn({ onSignIn, config, error: externalError }: SignI
                             Sign In
                         </Button>
                     </CardActions>
-
+                    <CardContent>
+                        {(error || externalError) && <Typography sx={{ mt: 2 }} color="primary">{error || externalError}</Typography>}
+                    </CardContent>
                 </Box>
             </form>
         </DesignSystem>

--- a/public/edtech/config.json
+++ b/public/edtech/config.json
@@ -5,11 +5,11 @@
     "description": "Educational Technology News",
     "icons": {
         "light": {
-            "icon": "/edtech/favicon.png",
+            "icon": "/shared/svg/characters/biker.svg",
             "favicon": "/edtech/favicon.ico"
         },
         "dark": {
-            "icon": "/edtech/favicon.png",
+            "icon": "/shared/svg/characters/biker.svg",
             "favicon": "/edtech/favicon.ico"
         }
     },
@@ -20,25 +20,25 @@
     "cartridges": {
         "designSystem": {
             "themeSwitching": false,
-            "defaultTheme": "light",
+            "defaultTheme": "dark",
             "themes": {
                 "light": {
                     "mode": "light",
-                    "primary": "#3877cf",
-                    "secondary": "#3877cf",
+                    "primary": "#2eaf4a",
+                    "secondary": "#2eaf4a",
                     "background": "#fff",
                     "paper": "#fff",
                     "text": "#000",
-                    "border": "#3877cf"
+                    "border": "#2eaf4a"
                 },
                 "dark": {
                     "mode": "dark",
-                    "primary": "#17A1AC",
-                    "secondary": "#07c7d5ff",
+                    "primary": "#1db954",
+                    "secondary": "#21e065",
                     "background": "#000",
                     "paper": "#000",
                     "text": "#fff",
-                    "border": "#17A1AC"
+                    "border": "#222"
                 }
             }
         }

--- a/public/edtech/markdown/docker.md
+++ b/public/edtech/markdown/docker.md
@@ -5,6 +5,7 @@ title: Docker
 description: Learn Docker fundamentals for developers.
 tags: ed-tech, docker, devops, free
 smartImage: docker
+image: https://live.staticflickr.com/65535/55066164370_2470ff2c5c_b.jpg
 ---
 
 # Docker for Reluctant Developers: A Gentle Introduction

--- a/public/edtech/markdown/index.md
+++ b/public/edtech/markdown/index.md
@@ -5,7 +5,6 @@ title: Ed Tech.
 description: Educational Technology
 tags: nx, goldlabel, coding
 icon: flash
-smartImage: nextjs
 ---
 
 > Ace your software developer interviews. Master technical interview communication, behavioral questions, system design explanations, and English interview skills.

--- a/public/mcuk/README.md
+++ b/public/mcuk/README.md
@@ -1,3 +1,13 @@
+                "dark": {
+                    "mode": "dark",
+                    "primary": "#17A1AC",
+                    "secondary": "rgb(92, 244, 255)",
+                    "background": "#1a5054",
+                    "paper": "#000",
+                    "text": "#fff",
+                    "border": "#17A1AC"
+                }
+
         "commerce": {
             "enabled": true,
             "ads": [

--- a/public/mcuk/config.json
+++ b/public/mcuk/config.json
@@ -5,11 +5,11 @@
     "url": "https://listingslab.com",
     "icons": {
         "light": {
-            "icon": "/mcuk/favicon.png",
+            "icon": "/shared/svg/characters/punk.svg",
             "favicon": "/mcuk/favicon.ico"
         },
         "dark": {
-            "icon": "/mcuk/favicon.png",
+            "icon": "/shared/svg/characters/punk.svg",
             "favicon": "/mcuk/favicon.ico"
         }
     },
@@ -20,7 +20,7 @@
     "cartridges": {
         "designSystem": {
             "themeSwitching": false,
-            "defaultTheme": "light",
+            "defaultTheme": "dark",
             "themes": {
                 "light": {
                     "mode": "light",
@@ -38,7 +38,7 @@
                     "background": "#000",
                     "paper": "#000",
                     "text": "#fff",
-                    "border": "#17A1AC"
+                    "border": "#19646a"
                 }
             }
         }

--- a/public/mcuk/markdown/index.md
+++ b/public/mcuk/markdown/index.md
@@ -2,7 +2,7 @@
 order: 1
 slug: /
 icon: home
-title: MCUK
+title: Diary of a pothead
 description: Medical Cannabis UK
 smartImage: monkey-doctor
 tags: medical cannabis, uk, prescription, licensed pharmacies, CBPM, legal,  


### PR DESCRIPTION
Updates tenant branding/theme configuration and refines a few UI components in the NX DesignSystem/Paywall to align with updated theming and layout.

**Changes:**
- Update MCUK/EdTech tenant config icons and default theme colors (switch default theme to dark).
- Content/frontmatter tweaks in tenant markdown (title change, add docker page image, remove edtech smartImage).
- UI adjustments: simplify `ThemedIcon`, tweak footer menu placement, and move/sign-in error rendering.

### Reviewed changes

Copilot reviewed 10 out of 10 changed files in this pull request and generated 3 comments.

<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| public/mcuk/markdown/index.md | Updates MCUK landing page frontmatter title. |
| public/mcuk/config.json | Switches tenant icon assets and default theme to dark; tweaks dark border color. |
| public/mcuk/README.md | Adds a theme JSON fragment at top of README. |
| public/edtech/markdown/index.md | Removes `smartImage` from frontmatter. |
| public/edtech/markdown/docker.md | Adds `image` to frontmatter. |
| public/edtech/config.json | Switches tenant icon assets and default theme to dark; updates palette values. |
| app/NX/Paywall/components/SignIn.tsx | Moves error rendering and adjusts its styling. |
| app/NX/DesignSystem/components/ThemedIcon.tsx | Removes nested clickable wrapper and router navigation; now renders only the avatar. |
| app/NX/DesignSystem/components/SettingsMenu.tsx | Adjusts theme toggle label text. |
| app/NX/DesignSystem/components/Footer.tsx | Reorders `SettingsMenu` placement in footer layout. |


