### PR TITLE
1.9.4

### DIFF
--- a/app/NX/DesignSystem/components/Icon.tsx
+++ b/app/NX/DesignSystem/components/Icon.tsx
@@ -168,13 +168,17 @@ import MathsIcon from '@mui/icons-material/Calculate';
 import VirusIcon from '@mui/icons-material/Coronavirus';
 import ForwardIcon from '@mui/icons-material/Send';
 import FirebaseIcon from '@mui/icons-material/Whatshot';
-import MediaIcon from '@mui/icons-material/CloudUpload';
+import MediaIcon from '@mui/icons-material/AttachFile';
 import CashIcon from '@mui/icons-material/Savings';
+import TenantIcon from '@mui/icons-material/BrowserUpdated';
 
 export default function Icon({ icon, color }: I_Icon) {
   if (!color) color = 'inherit';
   let iconFragment = <React.Fragment />;
   switch (icon) {
+    case 'tenant':
+      iconFragment = <TenantIcon color={color} />;
+      break;
     case 'cash':
       iconFragment = <CashIcon color={color} />;
       break;

--- a/app/NX/NXAdmin/Layout.tsx
+++ b/app/NX/NXAdmin/Layout.tsx
@@ -23,11 +23,13 @@ import {
     setNXAdmin,
     Dashboard,
     NXAdminMenu,
+    Collection,
+    MiniListItem,
 } from '../NXAdmin';
 import nav from './nav.json';
 import { useDispatch } from '../Uberedux';
 
-const drawerWidth = 320;
+const drawerWidth = 220;
 
 const openedMixin = (theme: Theme): CSSObject => ({
     width: drawerWidth,
@@ -101,16 +103,16 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
 
 export default function Layout({ config }: { config: any }) {
     const dispatch = useDispatch();
+
     const nxAdmin = useNXAdmin();
+    const { active } = nxAdmin;
     const theme = useTheme();
+    
+
+    // Find the active nav item
+    const activeNavItem = nav.find(item => item.collection === active);
+
     const [open, setOpen] = React.useState(false);
-
-    // React.useEffect(() => {
-    //     if (!nxAdmin?.active) {
-    //         dispatch(setNXAdmin('active', 'users'));
-    //     }
-    // }, [dispatch, nxAdmin]);
-
     const handleDrawerOpen = () => {
         setOpen(true);
     };
@@ -127,36 +129,47 @@ export default function Layout({ config }: { config: any }) {
                 sx={{
                     backgroundColor: theme.palette.background.paper,
                     border: 0,
+                    boxShadow: 0,
                 }}
             >
                 <Toolbar>
                     <IconButton
-                        color="inherit"
+                        color="primary"
                         aria-label="open drawer"
                         onClick={handleDrawerOpen}
                         edge="start"
                         sx={[
                             {
-                                marginRight: 5,
+                                marginRight: 3,
                             },
                             open && { display: 'none' },
                         ]}
                     >
-                        <ThemedIcon config={config}/>
+                        <Icon icon='right' />
                     </IconButton>
-                    <Typography variant="h6" noWrap component="div">
-                        {config.siteName} NX
+                    <ThemedIcon config={config} />
+                    <Typography sx={{ml:2}} variant="h6" color="primary" noWrap component="div">
+                        {config.siteName} Admin
                     </Typography>
                 </Toolbar>
             </AppBar>
-            <Drawer variant="permanent" open={open}>
-                <DrawerHeader>
+            <Drawer variant="permanent" open={open} sx={{ border: 0, }}>
+                <DrawerHeader sx={{ border: 0, }}>
                     <IconButton onClick={handleDrawerClose}>
-                        {theme.direction === 'rtl' ? <Icon icon="right" /> : <Icon icon="left" />}
+                        {theme.direction === 'rtl' ? <Icon icon="right" color="primary" /> : <Icon icon="left" color="primary" />}
                     </IconButton>
                 </DrawerHeader>
-                <Divider />
                 <List>
+                    <MiniListItem 
+                        open={open}
+                        options={{
+                            label: 'Home',
+                            icon: 'home',
+                            route: '/nx-admin',
+                        }}
+                    />
+                    <Divider sx={{my:2}}/>
+                   
                     {nav.map((item, i: number) => (
                         <ListItem
                             key={`item_${i}`}
@@ -193,7 +206,16 @@ export default function Layout({ config }: { config: any }) {
             </Drawer>
             <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
                 <DrawerHeader />
-                <Dashboard nav={nav} />
+                {/* <pre>active: {JSON.stringify(active, null, 2)}</pre> */}
+                {!active && <Dashboard nav={nav} />}
+                {active && activeNavItem && (
+                    <Collection
+                        collection={activeNavItem.collection}
+                        title={activeNavItem.title}
+                        description={activeNavItem.description}
+                        icon={activeNavItem.icon}
+                    />
+                )}
             </Box>
         </Box>
     );

--- a/app/NX/NXAdmin/NXAdmin.tsx
+++ b/app/NX/NXAdmin/NXAdmin.tsx
@@ -2,20 +2,13 @@
 import type { T_Config } from '../types';
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
-import { useActive } from './hooks/useActive';
-import { useScrollToRoot } from './hooks/useScrollToRoot';
 import {
-  Box,
-} from '@mui/material';
-import {
-  useNXAdmin,
   Layout,
 } from '../NXAdmin';
 import {
   DesignSystem,
   Feedback,
   useDesignSystem,
-  setDesignSystem,
 } from '../DesignSystem';
 import { useDispatch } from '../Uberedux';
 
@@ -23,16 +16,6 @@ export interface I_NXAdmin {
   config: T_Config;
   children?: React.ReactNode;
 };
-
-const collections = [
-  {
-    collection: 'users',
-    title: 'Users',
-    single: 'user',
-    description: 'Manage user accounts and permissions',
-    icon: 'users',
-  },
-];
 
 export default function NXAdmin({
   config,
@@ -49,7 +32,6 @@ export default function NXAdmin({
   const themeObj = (designSystem?.themes && designSystem?.themes[themeMode])
     || configThemes[themeMode]
     || configThemes[configDefaultTheme];
-
 
   return (
     <>

--- a/app/NX/NXAdmin/components/CRUD/ReadDoc.tsx
+++ b/app/NX/NXAdmin/components/CRUD/ReadDoc.tsx
@@ -25,6 +25,8 @@ function SingleDoc({
 }) {
   const dispatch = useDispatch();
   const {
+    label,
+    description,
     avatar,
     name,
     email,
@@ -37,18 +39,18 @@ function SingleDoc({
     dispatch(setCRUD(collection, 'mode', 'update'));
   }
 
-  return <ListItemButton onClick={handleSelect} disableGutters>
+  return <ListItemButton onClick={handleSelect}>
     {/* <pre>SingleDoc {JSON.stringify(doc, null, 2)}</pre> */}
 
-    <ListItemAvatar>
+    {/* <ListItemAvatar>
       <Avatar
         src={avatar}
         alt={name || 'No Name'}
       />
-    </ListItemAvatar>
+    </ListItemAvatar> */}
     <ListItemText
-      primary={name || 'No Name'}
-      secondary={email || 'No Email'}
+      primary={label}
+      secondary={description}
     />
   </ListItemButton>
 }
@@ -65,8 +67,12 @@ export default function ReadDoc({
     email: 'test@test.com',
 
   };
-
-  return <List dense>
+  return <>
+    {docs.map((doc: any, i: number) => (
+      <SingleDoc key={`doc_${i}`} collection={collection} doc={doc} />
+    ))  }
+  </>;
+  return <List>
     <SingleDoc doc={firstDoc} collection={collection} />
   </List>
 }

--- a/app/NX/NXAdmin/components/Collection/Collection.tsx
+++ b/app/NX/NXAdmin/components/Collection/Collection.tsx
@@ -4,8 +4,6 @@ import {
   Card,
   Tooltip,
   CardHeader,
-  Button,
-  CardContent,
   IconButton,
 } from '@mui/material';
 import { Icon } from '../../../DesignSystem';
@@ -19,8 +17,9 @@ import {
   UpdateDoc,
   DeleteDoc,
   setCRUD,
+  CancelActive,
 } from '../../../NXAdmin'
-import { useDispatch } from '../../../Uberedux'
+import { useDispatch } from '../../../Uberedux';
 
 export interface I_Collection {
   collection: string;
@@ -39,8 +38,8 @@ export default function Collection({
   const collectionState = useCollection(collection);
   const state = collectionState[collection];
 
-  let cardTitle: string = `TITLE ${title}`;
-  let cardSubheader: string = `DES ${description}`;
+  let cardTitle: string = `${title}`;
+  let cardSubheader: string = `${description}`;
 
   // Ensure cardTitle and cardSubheader are always strings at runtime
   if (typeof cardTitle !== 'string') {
@@ -53,6 +52,7 @@ export default function Collection({
   const {
     mode,
     selected,
+    docs,
     // typescript,
   } = state || {};
 
@@ -94,26 +94,17 @@ export default function Collection({
         <CardHeader
           title={cardTitle}
           subheader={cardSubheader}
-          action={<IconButton
-            color="primary"
-            onClick={() => handleNew(collection)}
-          >
-            <Icon icon="new" />
-          </IconButton>}
-          // action={
-          //   <>
-          //     {mode !== 'create' && <>
+          action={<>
+         
+            <IconButton
+              color="primary"
+              onClick={() => handleNew(collection)}
+            >
+              <Icon icon="new" />
+            </IconButton>
+            <CancelActive collection={collection} />
 
-          //     </>}
-          //     {selected || mode === "create" && <>
-          //       <IconButton
-          //         color="primary"
-          //         onClick={handleCancel}
-          //       >
-          //         <Icon icon="close" />
-          //       </IconButton>
-          //     </>}
-          //   </>}
+          </>}
           avatar={<Icon icon={icon as any} color="primary" />}
           sx={{
             '& .MuiCardHeader-subheader': {
@@ -130,7 +121,7 @@ export default function Collection({
           {mode === 'update' && <UpdateDoc collection={collection} />}
           {mode === 'delete' && <DeleteDoc collection={collection} />}
         </>}
-        <pre>selected: {JSON.stringify(selected, null, 2)}</pre>
+        {/* <pre>docs: {JSON.stringify(docs, null, 2)}</pre> */}
       </Card>
     </>
   );

--- a/app/NX/NXAdmin/components/Menus/CancelActive.tsx
+++ b/app/NX/NXAdmin/components/Menus/CancelActive.tsx
@@ -1,0 +1,32 @@
+'use client';
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  IconButton,
+  Button,
+} from '@mui/material';
+import { useDispatch } from '../../../../NX/Uberedux';
+import { setNXAdmin, setCRUD, useCRUD } from '../../../NXAdmin'
+import { Icon } from '../../../../NX/DesignSystem';
+
+export default function CancelActive({ 
+  collection 
+}: { 
+  collection: string
+}) {
+
+  const dispatch = useDispatch();
+  const crud = useCRUD();
+  const state = crud[collection];
+  const handleClick = () => {
+    console.log('collection', collection);
+    dispatch(setNXAdmin('active', null));
+  };
+  // console.log('state', state);
+  // Cancel
+  return (
+    <IconButton color="primary" onClick={handleClick}>
+      <Icon icon="close" />
+    </IconButton>
+  );
+}

--- a/app/NX/NXAdmin/components/Menus/Dashboard.tsx
+++ b/app/NX/NXAdmin/components/Menus/Dashboard.tsx
@@ -8,18 +8,27 @@ import {
     Typography,
 } from '@mui/material';
 import { Icon } from '../../../../NX/DesignSystem';
+import { useDispatch } from '../../../../NX/Uberedux';
+import {setNXAdmin} from '../../../NXAdmin'
 
 export default function Dashboard({ nav }: { nav: any }) {
 
-    const router = useRouter();
+    const dispatch = useDispatch();
+
+    const handleClick = (item: any) => {
+        if (item.collection) {
+            dispatch(setNXAdmin('active', item.collection));
+        }
+    };
 
     return (
         <>
             {Array.isArray(nav) && nav.map((item: any, i: number) => (
                 <ButtonBase
+                    onClick={() => handleClick(item)}
                     key={`navItem_${i}`}
                     sx={{
-                        m:1,
+                        my:1,
                         textAlign: 'left',
                         width: '100%',
                     }}
@@ -33,7 +42,7 @@ export default function Dashboard({ nav }: { nav: any }) {
                         }}
                     >
                         <Box sx={{mr:2}}>
-                            <Icon icon={item.icon} />
+                            <Icon icon={item.icon} color="primary"/>
                         </Box>
 
                         <Box>

--- a/app/NX/NXAdmin/components/Menus/MiniListItem.tsx
+++ b/app/NX/NXAdmin/components/Menus/MiniListItem.tsx
@@ -1,0 +1,66 @@
+'use client';
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  IconButton,
+  Button,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import { useDispatch } from '../../../../NX/Uberedux';
+// import { setNXAdmin, setCRUD, useCRUD } from '../../../NXAdmin'
+import { Icon } from '../../../../NX/DesignSystem';
+
+export default function MiniListItem({ 
+    open,
+options 
+}: { 
+  open: boolean;
+  options: {
+    label: string;
+    icon: string;
+    route?: string;
+  }
+}) {
+
+    const dispatch = useDispatch();
+    const router = useRouter();
+    const {
+        icon,
+        label = 'Dashboard',
+        route = '/nx-admin',
+    } = options;
+
+  return (
+      <ListItem
+          disablePadding
+          sx={{ display: 'block' }}>
+          <ListItemButton
+              onClick={() => {
+                window.location.href = route;
+              }}
+              sx={[
+                  { minHeight: 48, px: 2.5 },
+                  open ? { justifyContent: 'initial' } : { justifyContent: 'center' },
+              ]}
+          >
+              <ListItemIcon
+                  sx={[
+                      { minWidth: 0, justifyContent: 'center' },
+                      open ? { mr: 3 } : { mr: 'auto' },
+                  ]}
+              >
+                  <Icon icon={icon as any} color="primary" />
+              </ListItemIcon>
+              <ListItemText
+                  primary={label}
+                  sx={[
+                      open ? { opacity: 1 } : { opacity: 0 },
+                  ]}
+              />
+          </ListItemButton>
+      </ListItem>
+  );
+}

--- a/app/NX/NXAdmin/index.tsx
+++ b/app/NX/NXAdmin/index.tsx
@@ -6,6 +6,7 @@ import { Collection } from './components/Collection';
 import { TypeScript } from './components/TypeScript';
 import NXAdminBtn from './components/Menus/NXAdminBtn';
 import CloseAdmin from './components/Menus/CloseAdmin';
+import CancelActive from './components/Menus/CancelActive';
 import NXAdminMenu from './components/Menus/NXAdminMenu';
 import { setNXAdmin } from './actions/setNXAdmin';
 import { setCRUD } from './actions/setCRUD';
@@ -15,13 +16,16 @@ import { useNXAdmin } from './hooks/useNXAdmin';
 import { useCRUD } from './hooks/useCRUD';
 import { useCollection } from './hooks/useCollection';
 import { useActive } from './hooks/useActive';
+import MiniListItem from './components/Menus/MiniListItem';
 
 export {
     NXAdmin,
     Layout,
     Dashboard,
     NXAdminBtn,
+    MiniListItem,
     CloseAdmin,
+    CancelActive,
     NXAdminMenu,
     CreateDoc,
     ReadDoc,

--- a/app/NX/NXAdmin/nav copy.json
+++ b/app/NX/NXAdmin/nav copy.json
@@ -1,0 +1,37 @@
+[
+    {
+        "collection": "users",
+        "title": "Users",
+        "single": "user",
+        "description": "Manage user accounts and permissions",
+        "icon": "users"
+    },
+    {
+        "collection": "share",
+        "single": "share",
+        "title": "Share",
+        "description": "Viral marketing landing pages",
+        "icon": "share"
+    },
+    {
+        "collection": "notify",
+        "single": "notification",
+        "title": "Notifications",
+        "description": "Notifications sent by email, SMS or push",
+        "icon": "notify"
+    },
+    {
+        "collection": "media",
+        "single": "media file",
+        "title": "Media",
+        "description": "Images, sounds, videos and PDFs etc",
+        "icon": "media"
+    },
+    {
+        "collection": "tenants",
+        "single": "tenant",
+        "title": "Tenants",
+        "description": "Only level 2 users should see this",
+        "icon": "admin"
+    }
+]

--- a/app/NX/NXAdmin/nav.json
+++ b/app/NX/NXAdmin/nav.json
@@ -7,18 +7,12 @@
         "icon": "users"
     },
     {
-        "collection": "share",
-        "single": "share",
-        "title": "Share",
-        "description": "Viral marketing landing pages",
-        "icon": "share"
-    },
-    {
-        "collection": "notify",
-        "single": "notification",
-        "title": "Notifications",
-        "description": "Notifications sent by email, SMS or push",
-        "icon": "notify"
+        "collection": "tenants",
+        "level": 2,
+        "single": "tenant",
+        "title": "Tenants",
+        "description": "Only level 2 users should see this",
+        "icon": "tenant"
     },
     {
         "collection": "media",
@@ -28,10 +22,10 @@
         "icon": "media"
     },
     {
-        "collection": "tenants",
-        "single": "tenant",
-        "title": "Tenants",
-        "description": "Only level 2 users should see this",
-        "icon": "admin"
+        "collection": "share",
+        "single": "share",
+        "title": "Share",
+        "description": "Viral marketing landing pages",
+        "icon": "share"
     }
 ]

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -288,6 +288,7 @@ export type I_Icon = {
     | 'plus'
     | 'dog'
     | 'about'
+    | 'tenant'
     | 'experience'
     | 'clients'
     | 'link'

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import { Metadata } from "next";
 import {
     Box,
     AppBar,
+    IconButton,
     CardHeader,
     Container,
     Typography,
@@ -119,7 +120,9 @@ export default async function Page(props: any) {
                         }}>
                         <Container maxWidth="lg">
                             <CardHeader
-                                avatar={<ThemedIcon config={config} />}
+                                avatar={<IconButton href='/'>
+                                    <ThemedIcon config={config} />
+                                </IconButton>}
                                 title={<Typography
                                     color='secondary'
                                     variant="h4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "scripts": {
     "dev": "yarn kill && yarn install && rm -rf .next && next dev -p 1999 --webpack",
     "build": "next build --webpack",

--- a/public/nx/config.json
+++ b/public/nx/config.json
@@ -4,7 +4,7 @@
     "description": "Multi-tenant NextJS",
     "url": "https://goldlabel.pro",
     "images": {
-        "light": "https://live.staticflickr.com/65535/54940372447_3ca7baef00_b.jpg",
+        "light": "https://live.staticflickr.com/65535/55065806556_6f6d91c14b_b.jpg",
         "dark": "/nx/gif/dark.gif"
     },
     "icons": {


### PR DESCRIPTION
Release bump to 1.9.4 with updates to NX Admin navigation/UI and CRUD list rendering.

**Changes:**
- Bumped package version and refreshed the public config “light” image.
- Updated NX Admin nav structure (including a new `tenant` icon) and drawer layout, adding `MiniListItem` and `CancelActive`.
- Adjusted CRUD read view to render docs dynamically and tweaked Collection header actions.

### Reviewed changes

Copilot reviewed 14 out of 15 changed files in this pull request and generated 9 comments.

<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| public/nx/config.json | Updates the public-facing “light” image URL. |
| package.json | Bumps package version to 1.9.4. |
| app/[[...slug]]/page.tsx | Makes the header avatar icon clickable (home link). |
| app/NX/types.d.ts | Adds `tenant` to the icon union type. |
| app/NX/NXAdmin/nav.json | Reorders nav and adds a `tenants` entry with `level: 2` and `icon: tenant`. |
| app/NX/NXAdmin/nav copy.json | Adds a duplicated “copy” of nav configuration. |
| app/NX/NXAdmin/index.tsx | Re-exports new menu components (`CancelActive`, `MiniListItem`). |
| app/NX/NXAdmin/components/Menus/MiniListItem.tsx | New compact drawer list item component. |
| app/NX/NXAdmin/components/Menus/Dashboard.tsx | Dashboard items now dispatch `setNXAdmin('active', ...)` on click. |
| app/NX/NXAdmin/components/Menus/CancelActive.tsx | New “close active collection” icon button. |
| app/NX/NXAdmin/components/Collection/Collection.tsx | Updates header/actions and removes debug output. |
| app/NX/NXAdmin/components/CRUD/ReadDoc.tsx | Changes read view to render a list of docs. |
| app/NX/NXAdmin/NXAdmin.tsx | Removes unused/old scaffolded collections code. |
| app/NX/NXAdmin/Layout.tsx | Narrows drawer width, adds “Home” item, and conditionally renders Dashboard vs Collection. |
| app/NX/DesignSystem/components/Icon.tsx | Changes media icon and adds `tenant` icon mapping. |

<summary>Comments suppressed due to low confidence (1)</summary>

**app/[[...slug]]/page.tsx:1**
* This IconButton has no accessible name. Add an `aria-label` (e.g., \"Go to home\") so screen readers can identify the control. Also, if this is meant to behave as a link, ensure it renders as an anchor/Next Link (e.g., set `component=\"a\"` or use Next.js `<Link>`), rather than relying on `href` on a button element.


