### PR TITLE
This PR updates client-side URL generation for the Virus share/copy UI to include the current page protocol

### DIFF
--- a/app/NX/Virus/Virus.tsx
+++ b/app/NX/Virus/Virus.tsx
@@ -35,12 +35,14 @@ export default function Virus({
   }
 
   React.useEffect(() => {
-    if (frontmatter && typeof window !== 'undefined') {
-      setUrl(window.location.hostname + (frontmatter.slug || '/'));
-    } else if (meta?.openGraph?.url) {
-      setUrl(meta.openGraph.url);
-    } else if (typeof window !== 'undefined') {
-      setUrl(window.location.href);
+    if (typeof window !== 'undefined') {
+      if (frontmatter) {
+        setUrl(window.location.protocol + '//' + window.location.hostname + (frontmatter.slug || '/'));
+      } else if (meta?.openGraph?.url) {
+        setUrl(meta.openGraph.url);
+      } else {
+        setUrl(window.location.href);
+      }
     }
   }, [frontmatter, meta]);
 

--- a/public/mcuk/config.json
+++ b/public/mcuk/config.json
@@ -20,7 +20,7 @@
     "cartridges": {
         "designSystem": {
             "themeSwitching": false,
-            "defaultTheme": "dark",
+            "defaultTheme": "light",
             "themes": {
                 "light": {
                     "mode": "light",


### PR DESCRIPTION
This PR updates client-side URL generation for the `Virus` share/copy UI to include the current page protocol, and also changes the default design theme for the `mcuk` tenant configuration.

**Changes:**
- Build share/copy URLs using `window.location.protocol` when `frontmatter` is present.
- Update `public/mcuk/config.json` to use `"defaultTheme": "light"`.

### Reviewed changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| public/mcuk/config.json | Changes the `mcuk` tenant’s default theme from dark to light. |
| app/NX/Virus/Virus.tsx | Adjusts URL construction logic to include protocol for generated share/copy links. |


