### PR TITLE
This pull request introduces a flexible layout system for the NXAdmin interface

### DIFF
--- a/app/NX/DesignSystem/components/Surface/Surface.tsx
+++ b/app/NX/DesignSystem/components/Surface/Surface.tsx
@@ -6,6 +6,7 @@ import {
     Box,
     Button,
     Collapse,
+    IconButton,
 } from '@mui/material';
 import { SurfaceAS } from './';
 import { useDispatch } from '../../../../NX/Uberedux';
@@ -125,14 +126,12 @@ export default function Surface({ options }: I_Surface) {
         <Box id={options.id} ref={clipRef}>
             <ReactMarkdown>{displayed}</ReactMarkdown>
             <Collapse in={done}>
-                <Button
-                    variant="contained"
+                <IconButton
+                    title={label}
                     onClick={onClick}
-                    startIcon={options.iconAlign !== 'right' ? <Icon icon={options.icon as any} /> : undefined}
-                    endIcon={options.iconAlign === 'right' ? <Icon icon={options.icon as any} /> : undefined}
                 >
-                    {label}
-                </Button>
+                    <Icon icon={options.icon as any} />
+                </IconButton>
                 
             </Collapse>
             {/* <pre>authed: {JSON.stringify(authed, null, 2)}</pre> */}

--- a/app/NX/NXAdmin/NXAdmin.tsx
+++ b/app/NX/NXAdmin/NXAdmin.tsx
@@ -2,7 +2,9 @@
 import type { T_Config } from '../types';
 import * as React from 'react';
 import {
-  Layout,
+  MiniDrawer,
+  SwipeDrawer,
+  MaxiDrawer,
 } from '../NXAdmin';
 import {
   DesignSystem,
@@ -29,11 +31,20 @@ export default function NXAdmin({
     || configThemes[themeMode]
     || configThemes[configDefaultTheme];
 
+  // Safely get layout value
+  const layout = config?.cartridges?.nxadmin?.layout;
+
   return (
     <>
       <DesignSystem config={config} theme={themeObj}>
         <Feedback />
-        <Layout config={config} />
+        {layout === 'swipedrawer' ? (
+          <SwipeDrawer config={config} />
+        ) : layout === 'maxidrawer' ? (
+          <MaxiDrawer config={config} />
+        ) : (
+          <MiniDrawer config={config} />
+        )}
       </DesignSystem>
     </>
   );

--- a/app/NX/NXAdmin/components/CRUD/ReadDoc.tsx
+++ b/app/NX/NXAdmin/components/CRUD/ReadDoc.tsx
@@ -1,6 +1,10 @@
 'use client';
 import * as React from 'react';
-import type { I_ReadDoc } from '../../types';
+// import type { I_ReadDoc } from '../../types';
+
+export interface I_ReadDoc {
+  collection: string;
+}
 import {
   ListItemButton,
   ListItemText,

--- a/app/NX/NXAdmin/components/Layout/MaxiDrawer.tsx
+++ b/app/NX/NXAdmin/components/Layout/MaxiDrawer.tsx
@@ -1,0 +1,259 @@
+"use client";
+import * as React from 'react';
+import { styled, useTheme, Theme, CSSObject } from '@mui/material/styles';
+import MuiDrawer from '@mui/material/Drawer';
+import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
+import { getFirebaseAuth } from '../../../lib/firebase';
+import { useRouter } from 'next/navigation';
+import {
+    Box,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Toolbar,
+    IconButton,
+    CardHeader,
+    Avatar,
+    Typography,
+} from '@mui/material';
+import { 
+    Icon,
+    useDesignSystem,
+    setDesignSystem,
+} from '../../../DesignSystem';
+import {
+    useNXAdmin,
+    setNXAdmin,
+    Dashboard,
+    Collection,
+    MiniListItem,
+} from '../../../NXAdmin';
+import nav from '../../nav.json';
+import { useDispatch } from '../../../Uberedux';
+
+const drawerWidth = 320;
+
+const openedMixin = (theme: Theme): CSSObject => ({
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen,
+    }),
+    overflowX: 'hidden',
+});
+
+const closedMixin = (theme: Theme): CSSObject => ({
+    transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+    }),
+    overflowX: 'hidden',
+    width: `calc(${theme.spacing(7)} + 1px)`,
+    [theme.breakpoints.up('sm')]: {
+        width: `calc(${theme.spacing(8)} + 1px)`,
+    },
+});
+
+const DrawerHeader = styled('div')(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: theme.spacing(0, 1),
+    ...theme.mixins.toolbar,
+}));
+
+interface AppBarProps extends MuiAppBarProps {
+    open?: boolean;
+}
+
+const AppBar = styled(MuiAppBar, {
+    shouldForwardProp: (prop) => prop !== 'open',
+})<AppBarProps>(({ theme, open }) => ({
+    zIndex: theme.zIndex.drawer + 1,
+    transition: theme.transitions.create(['width', 'margin'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+    }),
+    ...(open && {
+        marginLeft: drawerWidth,
+        width: `calc(100% - ${drawerWidth}px)`,
+        transition: theme.transitions.create(['width', 'margin'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.enteringScreen,
+        }),
+    }),
+}));
+
+const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' })(
+    ({ theme, open }) => ({
+        width: drawerWidth,
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+        boxSizing: 'border-box',
+        ...(open
+            ? {
+                ...openedMixin(theme),
+                '& .MuiDrawer-paper': openedMixin(theme),
+            }
+            : {
+                ...closedMixin(theme),
+                '& .MuiDrawer-paper': closedMixin(theme),
+            }),
+    })
+);
+
+export default function MaxiDrawer({ config }: { config: any }) {
+
+    const dispatch = useDispatch();
+    const router = useRouter();
+    const [open, setOpen] = React.useState(false);
+    const nxAdmin = useNXAdmin();
+    const { active } = nxAdmin;
+    const theme = useTheme();
+    const activeNavItem = nav.find(item => item.collection === active);
+    const designSystem = useDesignSystem();
+    const currentThemeMode = designSystem?.themeMode ?? 'light';
+
+    const handleThemeModeToggle = () => {
+        const nextMode = currentThemeMode === 'light' ? 'dark' : 'light';
+        dispatch(setDesignSystem('themeMode', nextMode));
+    }
+
+
+    const handleDrawerOpen = () => {
+        setOpen(true);
+    };
+
+    const handleDrawerClose = () => {
+        setOpen(false);
+    };
+
+    const handleSignout = async () => {
+        const auth = getFirebaseAuth();
+        const { signOut } = await import('firebase/auth');
+        await signOut(auth);
+    };
+
+    return (
+        <Box sx={{ display: 'flex' }}>
+            <AppBar 
+                position="fixed" 
+                open={open}
+                sx={{
+                    background: 0,
+                    boxShadow: 0,
+                }}
+            >
+                <Toolbar sx={{background: 0}}>
+                    {!open && (
+                        <IconButton
+                            color="primary"
+                            aria-label="open drawer"
+                            onClick={handleDrawerOpen}
+                            edge="start"
+                            sx={{ marginRight: 3 }}
+                        >
+                            {theme.direction === 'rtl' ? <Icon icon="left" /> : <Icon icon="right" />}
+                        </IconButton>
+                    )}
+
+                    <CardHeader 
+                        sx={{width: '100%'}}
+                        title={<Typography variant="h6" color="text.secondary">{config.siteName}</Typography>}
+                        subheader={<Typography variant="body2" color="text.secondary">{config.description}</Typography>}
+                        avatar={
+                            <Avatar 
+                                src={config.avatars?.[currentThemeMode] ?? config.avatars?.light} 
+                                alt={config.siteName} />
+                        }
+                    />
+                </Toolbar>
+            </AppBar>
+            <Drawer variant="permanent" open={open} sx={{ border: 0, }}>
+                <DrawerHeader sx={{ border: 0 }}>
+                    {open && (
+                        <IconButton onClick={handleDrawerClose}>
+                            {theme.direction === 'rtl' ? <Icon icon="right" color="primary" /> : <Icon icon="left" color="primary" />}
+                        </IconButton>
+                    )}
+                </DrawerHeader>
+                <List>
+                    {nav.map((item, i: number) => (
+                        <ListItem
+                            key={`item_${i}`}
+                            disablePadding
+                            sx={{ display: 'block' }}>
+                            <ListItemButton
+                                onClick={() => dispatch(setNXAdmin('active', item.collection))}
+                                sx={[
+                                    { minHeight: 48, px: 2.5 },
+                                    open ? { justifyContent: 'initial' } : { justifyContent: 'center' },
+                                ]}
+                            >
+                                <ListItemIcon
+                                    sx={[
+                                        { minWidth: 0, justifyContent: 'center' },
+                                        open ? { mr: 3 } : { mr: 'auto' },
+                                    ]}
+                                >
+                                    <Icon icon={item.icon as any} color="primary" />
+                                </ListItemIcon>
+                                <ListItemText
+                                    primary={item.title}
+                                    sx={[
+                                        open ? { opacity: 1 } : { opacity: 0 },
+                                    ]}
+                                />
+                            </ListItemButton>
+                        </ListItem>
+                    ))}
+                </List>
+                
+                <Box sx={{flexGrow: 1}} />
+                
+                <MiniListItem
+                    open={open}
+                    onClick={handleThemeModeToggle}
+                    options={{
+                        label: currentThemeMode === 'light' ? 'Dark mode' : 'Light mode',
+                        icon: currentThemeMode === 'light' ? 'darkmode' : 'lightmode',
+                    }}
+                />
+
+                <MiniListItem
+                    open={open}
+                    onClick={handleSignout}
+                    options={{
+                        label: 'Sign out',
+                        icon: 'signout',
+                    }}
+                />
+                <MiniListItem
+                    open={open}
+                    onClick={() => {
+                        window.location.href = '/';
+                    }}
+                    options={{
+                        label: 'Public',
+                        icon: 'public',
+                    }}
+                />
+            </Drawer>
+            <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+                <DrawerHeader />
+                {!active && <Dashboard nav={nav} />}
+                {active && activeNavItem && (
+                    <Collection
+                        collection={activeNavItem.collection ?? ""}
+                        title={activeNavItem.title}
+                        description={activeNavItem.description}
+                        icon={activeNavItem.icon}
+                        single={activeNavItem.single}
+                    />
+                )}
+            </Box>
+        </Box>
+    );
+}

--- a/app/NX/NXAdmin/components/Layout/MiniDrawer.tsx
+++ b/app/NX/NXAdmin/components/Layout/MiniDrawer.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { styled, useTheme, Theme, CSSObject } from '@mui/material/styles';
 import MuiDrawer from '@mui/material/Drawer';
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
-import { getFirebaseAuth } from '../../lib/firebase';
+import { getFirebaseAuth } from '../../../lib/firebase';
 import { useRouter } from 'next/navigation';
 import {
     Box,
@@ -22,16 +22,16 @@ import {
     Icon,
     useDesignSystem,
     setDesignSystem,
-} from '../../DesignSystem';
+} from '../../../DesignSystem';
 import {
     useNXAdmin,
     setNXAdmin,
     Dashboard,
     Collection,
     MiniListItem,
-} from '../../NXAdmin';
-import nav from '../nav.json';
-import { useDispatch } from '../../Uberedux';
+} from '../../../NXAdmin';
+import nav from '../../nav.json';
+import { useDispatch } from '../../../Uberedux';
 
 const drawerWidth = 320;
 
@@ -104,7 +104,7 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
     })
 );
 
-export default function Layout({ config }: { config: any }) {
+export default function MiniDrawer({ config }: { config: any }) {
 
     const dispatch = useDispatch();
     const router = useRouter();

--- a/app/NX/NXAdmin/components/Layout/SwipeDrawer.tsx
+++ b/app/NX/NXAdmin/components/Layout/SwipeDrawer.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { Global } from '@emotion/react';
+import { styled } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import { grey } from '@mui/material/colors';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+
+const drawerBleeding = 56;
+
+
+interface Props {
+    /**
+     * Injected by the documentation to work in an iframe.
+     * You won't need it on your project.
+     */
+    window?: () => Window;
+    config?: any;
+}
+
+const Root = styled('div')(({ theme }) => ({
+    height: '100%',
+    backgroundColor: grey[100],
+    ...theme.applyStyles('dark', {
+        backgroundColor: (theme.vars || theme).palette.background.default,
+    }),
+}));
+
+const StyledBox = styled('div')(({ theme }) => ({
+    backgroundColor: '#fff',
+    ...theme.applyStyles('dark', {
+        backgroundColor: grey[800],
+    }),
+}));
+
+const Puller = styled('div')(({ theme }) => ({
+    width: 30,
+    height: 6,
+    backgroundColor: grey[300],
+    borderRadius: 3,
+    position: 'absolute',
+    top: 8,
+    left: 'calc(50% - 15px)',
+    ...theme.applyStyles('dark', {
+        backgroundColor: grey[900],
+    }),
+}));
+
+export default function SwipeDrawer(props: Props) {
+    const { window, config } = props;
+    const [open, setOpen] = React.useState(false);
+
+    const toggleDrawer = (newOpen: boolean) => () => {
+        setOpen(newOpen);
+    };
+
+    // This is used only for the example
+    const container = window !== undefined ? () => window().document.body : undefined;
+
+    return (
+        <Root>
+            <CssBaseline />
+            <Global
+                styles={{
+                    '.MuiDrawer-root > .MuiPaper-root': {
+                        height: `calc(50% - ${drawerBleeding}px)`,
+                        overflow: 'visible',
+                    },
+                }}
+            />
+            <Box sx={{ textAlign: 'center', pt: 1 }}>
+                <Button onClick={toggleDrawer(true)}>Open</Button>
+            </Box>
+            <SwipeableDrawer
+                container={container}
+                anchor="bottom"
+                open={open}
+                onClose={toggleDrawer(false)}
+                onOpen={toggleDrawer(true)}
+                swipeAreaWidth={drawerBleeding}
+                disableSwipeToOpen={false}
+                keepMounted
+            >
+                <StyledBox
+                    sx={{
+                        position: 'absolute',
+                        top: -drawerBleeding,
+                        borderTopLeftRadius: 8,
+                        borderTopRightRadius: 8,
+                        visibility: 'visible',
+                        right: 0,
+                        left: 0,
+                    }}
+                >
+                    <Puller />
+                    <Typography sx={{ p: 2, color: 'text.secondary' }}>51 results</Typography>
+                </StyledBox>
+                <StyledBox sx={{ px: 2, pb: 2, height: '100%', overflow: 'auto' }}>
+                    <Skeleton variant="rectangular" height="100%" />
+                </StyledBox>
+            </SwipeableDrawer>
+        </Root>
+    );
+}

--- a/app/NX/NXAdmin/components/Layout/index.tsx
+++ b/app/NX/NXAdmin/components/Layout/index.tsx
@@ -1,0 +1,9 @@
+import MiniDrawer from './MiniDrawer';
+import MaxiDrawer from './MaxiDrawer';
+import SwipeDrawer from './SwipeDrawer';
+
+export { 
+    MiniDrawer,
+    MaxiDrawer,
+    SwipeDrawer,
+};

--- a/app/NX/NXAdmin/index.tsx
+++ b/app/NX/NXAdmin/index.tsx
@@ -1,5 +1,5 @@
 import NXAdmin from './NXAdmin';
-import Layout from './components/Layout';
+import { MiniDrawer, SwipeDrawer, MaxiDrawer } from './components/Layout';
 import Dashboard from './components/Menus/Dashboard';
 import { CreateDoc, ReadDoc, UpdateDoc, DeleteDoc } from './components/CRUD';
 import { Collection } from './components/Collection';
@@ -27,9 +27,11 @@ import JSONInput from './components/UI/JSONInput';
 
 export {
     NXAdmin,
+    MaxiDrawer,
+    SwipeDrawer,
     InputString,
     OptionSelect,
-    Layout,
+    MiniDrawer,
     Dashboard,
     NXAdminBtn,
     MiniListItem,

--- a/app/NX/NXAdmin/types.d.ts
+++ b/app/NX/NXAdmin/types.d.ts
@@ -1,5 +1,0 @@
-export interface I_ReadDoc {
-    collection: string;
-    doc?: Record<string, any>;
-    typescript?: Record<string, any>;
-}

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -31,6 +31,7 @@ export type T_Config = {
     cartridges: {
         nxadmin?: {
             enabled: boolean;
+            layout?: 'swipedrawer' | 'minidrawer' | 'maxidrawer';
         },
         async?: {
             enabled: boolean;

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -122,14 +122,14 @@ export default async function Page(props: any) {
 
                     <Box
                         sx={{
-                            display: { xs: 'none', md: 'flex' },
+                            display: { xs: 'none', sm: 'flex' },
                             flexDirection: 'column',
                         }}
                     >
                         <Box sx={{
                             flexGrow: 1,
-                            minHeight: 0,
-                            minWidth: 300,
+                                minHeight: 0,
+                                minWidth: 250,
                         }}>
                             <TreeNav navItems={navItems}/>                            
                         </Box>

--- a/public/echopay/config.json
+++ b/public/echopay/config.json
@@ -18,13 +18,14 @@
     },
     "cartridges": {
         "nxadmin": {
-            "enabled": false
+            "enabled": false,
+            "layout": "minidrawer"
         },
         "async": {
             "enabled": false
         },
         "paywall": {
-            "enabled": true
+            "enabled": false
         },
         "designSystem": {
             "themeSwitching": true,

--- a/public/edtech/config.json
+++ b/public/edtech/config.json
@@ -25,7 +25,7 @@
         },
         "designSystem": {
             "themeSwitching": true,
-            "defaultTheme": "dark",
+            "defaultTheme": "light",
             "themes": {
                 "light": {
                     "mode": "light",

--- a/public/nhtfs/config.json
+++ b/public/nhtfs/config.json
@@ -18,7 +18,8 @@
     },
     "cartridges": {
         "nxadmin": {
-            "enabled": false
+            "enabled": false,
+            "layout": "maxidrawer"
         },
         "async": {
             "enabled": false

--- a/public/nhtfs/markdown/bez/index.md
+++ b/public/nhtfs/markdown/bez/index.md
@@ -1,0 +1,11 @@
+---
+order: 500
+slug: /bez
+title: Bez
+description: Turbo inject 5 bongs
+tags: bez
+icon: writing
+image: https://live.staticflickr.com/65535/54340497432_b8c92a3215_b.jpg
+---
+
+> Bastards, sir. Lot’s of bastards

--- a/public/nhtfs/markdown/dog/index.md
+++ b/public/nhtfs/markdown/dog/index.md
@@ -1,0 +1,41 @@
+---
+order: 999
+slug: /dog
+title: dog
+description: I am dog
+tags: dog
+icon: dog
+image: https://live.staticflickr.com/65535/54353713944_5571897d59_b.jpg
+---
+
+Usually, when the wizardz start waking up, I am on the bed. If they are not too grumpy, I might try lickin. Lickin is my faaaaavourite thing.
+
+In the morning, it is very important to follow the wizardz closely because sometimes the fluffy wizard gives out bisskits. Bisskits are crunchy and mouth-happy and my faaaaavourite thing.
+
+The wizardz have a loudbox called Van. It is mad. You get in it, and everything goes mental for ages. Windyface! Too too too many smells! Then it stops, and you could be anywhere. Most of the time, I don’t know where I am.
+
+Some days we go to beach.
+Oh, I luuuuuvvvv beach.
+It is sandysalty and wetsmelly and birdychasy and otherdoggy. But when we get home, sometimes I have a bath. Bath is not my faaaaavourite thing.
+
+I am digging a hole behind the shed under the ropeytreevinefing. Today, I got stuck in the ropeytreevine and had to wait for a wizard to come get me out. That kind of thing happens a lot when you are Sillydog.
+
+When it is darktime and the wizardz have humanfood, I stare at them until they give me some. Sometimes, if I am very lucky, I get a fing.
+
+Fings are great.
+I do not normally have fings.
+Usually, people take fings away from me.
+
+When I get a fing, I like to take it away and look at it. Then I like to show it to the wizardz. Then I eat it just in case it is food.
+
+My bed is on the floor next to the wizardz, but as soon as big wizard snores, I jump on the bed.
+
+In the sleepworld otherplace, I chase rabbits and bark a little bit. But that is a whole other story.
+
+Fluffy wizard says I snore as loud as big wizard, but I do not believe her.
+
+I get in the way a lot. Wizardz accidentally boot me in the gish. Dun’t matter. It’s pretty good being Sillydog.
+
+The only thing that ever troubles me is...
+
+What if I never find out who’s a good doggy?

--- a/public/nhtfs/markdown/dog/who-is-dog.md
+++ b/public/nhtfs/markdown/dog/who-is-dog.md
@@ -1,0 +1,31 @@
+---
+order: 255
+slug: /dog/who-is-dog
+title: Who is Dog?
+description: Endlessly affectionate, completely clueless
+tags: dog
+icon: dog
+image: https://live.staticflickr.com/65535/54353713944_5571897d59_b.jpg
+---
+Dog is….. obviously… a dog. She’s a nice dog, but not very bright. When we meet her she’s about 11 years old. She’s never been trained and being a Shitzu Maltese cross, which are supposedly hard to train she’s not going to be learning anything new anytime. w
+
+She’s nice, though. Show her a ball and she’ll have no idea what you mean. She’ll just try to lick you. Because licking humans is what she lives for.
+
+Name: Dog (because what else would you call her?)
+Breed: Shih Tzu-Maltese cross
+Age: 11 years old
+Personality: Endlessly affectionate, completely clueless
+
+- Has never been trained and shows no particular inclination to start now
+- Responds to most situations with either enthusiastic tail wagging or mild confusion
+- Absolutely no concept of fetch—show her a ball, and she’ll stare blankly before deciding to lick your hand instead
+- Licking is her one true purpose in life; if there is a human nearby, she must lick them
+- Can be alarmingly persistent about getting close enough to deliver licks, even in situations where it is neither appropriate nor wanted
+- Not particularly aware of personal space, frequently found sitting on people rather than next to them
+- Barks at seemingly random things—air, distant sounds, the concept of existence—then forgets why and settles back down
+- Grooming is a lost cause; even on a good day, she looks slightly disheveled, like an old mop that’s given up on life
+- Deeply content with the simplest pleasures: a warm lap, a kind voice, and unlimited licking opportunities
+
+Not a guard dog, not a working dog, not a particularly useful dog in any capacity—but she is a nice dog, and that’s all that really matters.
+
+Dog is the kind of companion who brings zero practicality but 100% unfiltered love. She may not fetch, heel, or do anything remotely impressive, but she will sit by your side (or on your foot) and lick your hand with the unwavering devotion of a creature who knows that her only job is to love humans. And in that, she excels.

--- a/public/nhtfs/markdown/dog/wigglepud-lady.md
+++ b/public/nhtfs/markdown/dog/wigglepud-lady.md
@@ -1,0 +1,33 @@
+---
+order: 200
+slug: /dog/wigglepud-lady
+title: Wigglepud Lady
+description: She didn’t just lick the wigglepud. She lifted it up!
+tags: dog
+icon: dog
+image: https://live.staticflickr.com/65535/54353713944_5571897d59_b.jpg
+---
+
+I have heard a fing from the wizardz.
+A lady got a baby little Fing. A wigglepud.
+And she picked it up.
+This was VERY BAD.
+I do not know why.
+
+Sometimes, when I find a baby thing, I lick it. That is my job. I am the best at licking. But wizardz say not all baby things want licking. This is very hard to understand. Who wouldn’t want a lick?
+
+But this lady did a worse thing. She didn’t just lick the wigglepud. She lifted it up! And then she did the human proud bark on Insta thing and showed all the other humans. And then the big angry noise started.
+
+The wizardz say she had to run away because the other humans wanted to bark at her. A lot. Like, BIG barking. Like when Not-Nice-Cat sits on my bed. That kind of barking, but from a whole country.
+
+She got on a fast-loud-human-thing called Plane. The wizardz say she left as quick as she could. Like when I am near the bath and then I am NOT near the bath. Like that.
+
+The wizardz say the wigglepud needed to be with its mum. That makes sense. When I was a tinydog, I needed my mum. But now I have wizardz, and I need wizardz. And I need biscuits. And bellyrubs. And sleeping in the big soft bed that is supposed to be for wizardz but also for Sillydog.
+
+Wizard says humans do not always know what is good for wigglepuds or doggies or anything at all. This is why wizardz have to tell other wizardz not to pick up wigglepuds and why I have to be told not to steal sausages from plates. I know this is a rule but sometimes I forget. Maybe the lady forgot too. But now she remembers because the big angry noise was very, very loud.
+
+I still think licking is always okay, though.
+Unless it is bath.
+Then nothing is okay.
+
+The End.

--- a/public/nhtfs/markdown/dog/wizards.md
+++ b/public/nhtfs/markdown/dog/wizards.md
@@ -1,0 +1,10 @@
+---
+order: 150
+slug: /dog/wizards
+title: Who are Wizards?
+description: Any sufficiently advanced technology is indistinguishable from magic
+tags: dog
+icon: dog
+image: https://live.staticflickr.com/65535/54353713944_5571897d59_b.jpg
+---
+Arthur C. Clarke said that any sufficiently advanced technology is indistinguishable from magic. He was talking about progress—the kind that sneaks up on you. One day you’re rubbing sticks together for fire, the next you’ve got a pocket-sized rectangle that can summon food, light, or a hundred strangers willing to drive you anywhere for money. But he could just as easily have been talking about my dog. Dog just knows that when I open the fridge, food appears. When I leave, I vanish. When I return, I reappear. I must be a wizard.

--- a/public/nhtfs/markdown/index.md
+++ b/public/nhtfs/markdown/index.md
@@ -4,8 +4,8 @@ slug: /
 title: Not here to fuck spiders
 description: by Wei Zang
 tags: wei zang,
-icon: home
-image: /nhtfs/jpg/default.jpg
+icon: writing
+image: https://live.staticflickr.com/65535/55016269007_092c55e1ba_b.jpg
 ---
 
-Instead of asking how AI will help us do a Jigsaw puzzle, we'll focus on explaining to AI why jigsaws exist. They give us something to do. Otherwise we'd just pick peanuts out of poo, eat the peanuts and fling the poo at each other
+Instead of asking how AI will help us do a Jigsaw puzzle, we'll focus on explaining to AI why jigsaws exist. They give us something to do. Otherwise we'd just picking peanuts out of poo, eating the peanuts and flinging the poo at each other

--- a/public/nhtfs/markdown/wei-zang/index.md
+++ b/public/nhtfs/markdown/wei-zang/index.md
@@ -1,0 +1,36 @@
+---
+order: 300
+slug: /wei-zang
+title: Wei Zang
+description: the author
+tags: wei zang, auther
+icon: writing
+image: https://live.staticflickr.com/65535/54338019655_94e8e39903_b.jpg
+---
+Wei Zang  50 • Sydney
+
+伟张 Wei Zang 
+张伟 Zang Wei 
+魏章编年史 The Wei Zang Chronicles
+
+I am Zang Wei. At least, that would be the Western way of saying it. In China we would say it the other way around. Wei Zang.
+
+Family comes first.
+
+There I was. Working hard. I won't say which company, but it was for one of those big Western smartphone companies who manufacture their hardware in Shenzhen.
+Some people say that the Chinese are only good at srewing components together, but fuck them.
+
+They don't see the power of being able to mobilise a quarter of the world's population to efficiently not only produce what the world wants, but also to make all the components so cheaply while at the same time making friends with the folk who actually mine the raw materials.That kind of planning needs power.
+Sorry, I digress already.
+
+I felt - how should I put it - unfullfilled?
+
+Protagonist
+Chinese looking with heavily accented, but perfect English
+Personality : Acerbic
+Occupation: Software Developer
+Habits/Mannerisms
+Background
+Internal Conflicts
+External Conflicts
+


### PR DESCRIPTION
This pull request introduces a flexible layout system for the NXAdmin interface, allowing different drawer layouts (MiniDrawer, MaxiDrawer, SwipeDrawer) to be selected via configuration. It refactors the layout components into modular files, updates imports and exports accordingly, and adds new layout components. Configuration files are updated to specify the desired layout per environment. There are also minor UI improvements and a new markdown file.

**Layout System Refactor and Modularization**
- Refactored the main layout logic in `NXAdmin.tsx` to select between `MiniDrawer`, `MaxiDrawer`, and `SwipeDrawer` based on the `layout` property in the configuration (`config.cartridges.nxadmin.layout`). The default is now `MiniDrawer` if not specified. [[1]](diffhunk://#diff-8ed8065c822f81806d8db611493b8ca96426e7fced86fdb6d23ff3965ceb539fL5-R7) [[2]](diffhunk://#diff-8ed8065c822f81806d8db611493b8ca96426e7fced86fdb6d23ff3965ceb539fR34-R47)
- Split the previous monolithic `Layout.tsx` into three modular components: `MiniDrawer.tsx`, `MaxiDrawer.tsx`, and `SwipeDrawer.tsx`, each implementing a different navigation drawer style. [[1]](diffhunk://#diff-346813489ea9e17367ef5419b32ce58416251bd660f7b4133a1a3d56b0d8126aL6-R6) [[2]](diffhunk://#diff-346813489ea9e17367ef5419b32ce58416251bd660f7b4133a1a3d56b0d8126aL25-R34) [[3]](diffhunk://#diff-346813489ea9e17367ef5419b32ce58416251bd660f7b4133a1a3d56b0d8126aL107-R107) [[4]](diffhunk://#diff-04e0d7c468dbd86983bd02af467b32915b13c07550a67da790f9ef051f99846aR1-R259) [[5]](diffhunk://#diff-d9bb365b29774f6ba2de395bebe0d2ea4360098e6df34690094a0a835e5be24aR1-R107) [[6]](diffhunk://#diff-59200204bb46bc47340fbc221d4d1a6a52a189698f12a15a99c697cfad2ab0f1R1-R9)
- Updated all relevant imports and exports to support the new modular layout structure, including `index.tsx` files and the NXAdmin barrel file. [[1]](diffhunk://#diff-a5ce165ab5bf79b2d36e70d817e21f26823aea5355e4dee8b4cde84115924531L2-R2) [[2]](diffhunk://#diff-a5ce165ab5bf79b2d36e70d817e21f26823aea5355e4dee8b4cde84115924531R30-R34) [[3]](diffhunk://#diff-59200204bb46bc47340fbc221d4d1a6a52a189698f12a15a99c697cfad2ab0f1R1-R9)

**Configuration and Theming Updates**
- Updated environment configuration files (`public/echopay/config.json`, `public/nhtfs/config.json`, `public/edtech/config.json`) to specify the `layout` property and adjust other settings such as theme defaults and paywall enablement. [[1]](diffhunk://#diff-e391125804d4ed0c3fd2de6eb6aa95efc7ed7d568103a1816f4e77c2df5fbc40L21-R28) [[2]](diffhunk://#diff-74d08bfcf5123a5ba49605732f01d0f370936c07b59d5f5ae48dc6cd6eeebaceL21-R22) [[3]](diffhunk://#diff-518b3805ed28c96426fc13aacc4c898300722e3bc6fdc8577135e2e627c07001L28-R28)

**Component and UI Improvements**
- Changed the action button in the `Surface` component from a `Button` to an `IconButton` for a more compact UI. [[1]](diffhunk://#diff-5d19158cd48a0b5bab3781b7192bc7762d47d307c3ccc73a2ea1391474bf6fa2R9) [[2]](diffhunk://#diff-5d19158cd48a0b5bab3781b7192bc7762d47d307c3ccc73a2ea1391474bf6fa2L128-R134)
- Minor UI tweaks to responsive breakpoints and sidebar width in the main page layout. ([app/[[...slug]]/page.tsxL125-R132](diffhunk://#diff-007d4a2548702159a27c456e316eaa3925ccc99123279aec8c19fe130436d246L125-R132))

**Other Changes**
- Added a new markdown content file `bez/index.md` with metadata and sample content.
- Provided a local interface for `I_ReadDoc` in `ReadDoc.tsx` for clarity and reduced dependency.