### PR TITLE
Add account page and user/account components

### DIFF
--- a/app/NX/DesignSystem/components/Header.tsx
+++ b/app/NX/DesignSystem/components/Header.tsx
@@ -11,6 +11,7 @@ import {
 	AppBar,
 	Typography,
 } from '@mui/material';
+import {User} from '../../Paywall';
 
 export interface I_Header {
 	config: T_Config;
@@ -32,7 +33,7 @@ export default function Header({
 	}
 
 	const handleUserClick = () => {
-		router.push('/nx-admin');
+		router.push('/account');
 	}
 
 	return (
@@ -46,12 +47,6 @@ export default function Header({
 				}}>
 				<Container maxWidth="lg">
 					<CardHeader
-					avatar={<IconButton onClick={handleAvatarClick}>
-								<Avatar src={avatar} />
-							</IconButton>}
-						action={<IconButton onClick={handleUserClick}>
-							<Avatar src={avatar} />
-						</IconButton>}
 					title={<Typography
 						color='secondary'
 						variant="h5"
@@ -60,6 +55,10 @@ export default function Header({
 					>
 						{title}
 					</Typography>}
+					avatar={<IconButton onClick={handleAvatarClick}>
+								<Avatar src={avatar} />
+							</IconButton>}
+					action={<User onClick={handleUserClick} />}
 				/>
 				</Container>
 			</AppBar>			

--- a/app/NX/Paywall/components/Account.tsx
+++ b/app/NX/Paywall/components/Account.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React from 'react';
+import { 
+    Box,
+    Card,
+    CardHeader,
+    CardContent,
+    CardActions,
+    Typography,
+    Button,
+ } from '@mui/material';
+import { useAuthed, usePaywall } from '../../Paywall';
+import { Icon } from '../../DesignSystem';
+
+export interface I_Account {
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+export default function Account({ onClick }: I_Account) {
+    
+    const paywall = usePaywall();
+    
+    return (<Card variant='outlined'>
+                <CardHeader 
+                avatar={<Icon icon="account" color="primary"/>}
+                title="Account" />
+                <CardContent>
+                    <pre>{JSON.stringify(paywall, null, 2)}</pre>
+                </CardContent>
+                <CardActions>
+                    <Box sx={{ flexGrow: 1 }} />
+                    <Button 
+                        endIcon={<Icon icon="save" />}
+                        variant='contained'
+                        onClick={onClick}>
+                        Save
+                    </Button>
+                </CardActions>
+            </Card>);
+
+}

--- a/app/NX/Paywall/components/SignOutBtn.tsx
+++ b/app/NX/Paywall/components/SignOutBtn.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { IconButton } from '@mui/material';
 import { Icon } from '../../DesignSystem';

--- a/app/NX/Paywall/components/User.tsx
+++ b/app/NX/Paywall/components/User.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { IconButton, Box, Avatar } from '@mui/material';
-import { useRouter } from 'next/navigation';
-import { useAsync } from '../../Async';
 import { useAuthed } from '../../Paywall';
+import { Icon } from '../../DesignSystem';
 
+export interface I_User {
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+}
 
-export default function User() {
+export default function User({ onClick }: I_User) {
+    const authed = useAuthed();
+    // const { avatar } = authed || {};
+
     
-    const async = useAsync();
-    const { ting } = async || {};
-    const {avatar} = ting || {};
-    if (!avatar) return null;
-    return (<>
-        <IconButton>
-            <Avatar src={avatar} />
+    return (
+        <IconButton onClick={onClick} color="primary">
+            <Icon icon={authed ? "user" : "account"} color="primary" />
         </IconButton>
-        </>
     );
 }

--- a/app/NX/Paywall/hooks/useAuthed.ts
+++ b/app/NX/Paywall/hooks/useAuthed.ts
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState } from "react";
 import { getFirebaseAuth } from "../../lib/firebase";
 import { User } from "firebase/auth";

--- a/app/NX/Paywall/index.tsx
+++ b/app/NX/Paywall/index.tsx
@@ -1,8 +1,9 @@
 
 import Paywall from "./Paywall";
-import SignIn from './components/SignIn'
-import User from './components/User'
-import SignOutBtn from './components/SignOutBtn'
+import SignIn from './components/SignIn';
+import User from './components/User';
+import Account from './components/Account';
+import SignOutBtn from './components/SignOutBtn';
 import { setPaywall } from './actions/setPaywall';
 import { firebaseLogin, firebaseLogout } from './actions/firebaseAuth';
 import { useAuthed } from './hooks/useAuthed';
@@ -11,6 +12,7 @@ import { subscribeUser } from './actions/subscribeUser';
 
 export {
     Paywall,
+    Account,
     SignIn,
     SignOutBtn,
     setPaywall,

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -2,7 +2,7 @@ import type { T_UbereduxDispatch, T_RootState } from '../NX/Uberedux/store';
 export type { T_UbereduxDispatch, T_RootState }
 
 export type T_Tenant = 'nx' |
-    'mcuk' |
+    'listingslab' |
     'echopay' |
     'edtech' | 
     'writing' | 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,146 @@
+import type { I_NestedNav, T_Tenant, T_Frontmatter } from '../NX/types';
+import fs from "fs";
+import matter from "gray-matter";
+import { notFound } from "next/navigation";
+import { Metadata } from "next";
+import {
+    Box,
+    Container,
+} from '@mui/material';
+import { NX } from '../NX';
+import {
+    serverUseMDBySlug,
+    serverUseAllMd,
+    serverUseNav,
+    getTenant,
+    getMeta,
+} from '../NX/lib';
+import {
+    Header,
+    Footer,
+    TreeNav,
+} from '../NX/DesignSystem';
+import {
+    Account,
+} from '../NX/Paywall';
+
+export async function generateMetadata({ params }: { params: any }): Promise<Metadata> {
+    const resolvedParams = typeof params.then === 'function' ? await params : params;
+    const slugArr = resolvedParams?.slug || [];
+    const tenant = process.env.NEXT_PUBLIC_TENANT || "nx";
+    const { config } = getTenant(tenant as T_Tenant);
+    const async = config.cartridges?.async?.enabled === true;
+    const filePath = serverUseMDBySlug(slugArr, tenant);
+    let frontmatter: T_Frontmatter = {};
+    if (filePath && fs.existsSync(filePath)) {
+        const md = fs.readFileSync(filePath, "utf-8");
+        const { data } = matter(md);
+        frontmatter = data;
+    }
+    let url = config.url || "";
+    const themeMode: 'light' | 'dark' = 'light';
+    let title = config.siteName || "";
+    let description = config.description || "";
+    let image = config.images?.[themeMode] || "";
+    if (filePath && fs.existsSync(filePath)) {
+        const md = fs.readFileSync(filePath, "utf-8");
+        const { data } = matter(md);
+        if (data?.title) title = data.title;
+        if (data?.description) description = data.description;
+        if (data?.url) url = data.url;
+        if (data?.image) image = data.image;
+    }
+    const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
+    const pageUrl = url.replace(/\/$/, "") + (slugPath ? `/${slugPath}` : "");
+
+    return getMeta({
+        siteName: title,
+        title: `${title}, ${description}`,
+        description,
+        image,
+        url: pageUrl,
+    });
+}
+
+export async function generateStaticParams() {
+    const tenant = process.env.NEXT_PUBLIC_TENANT || "nx";
+    const { markdownDir } = getTenant(tenant as T_Tenant);
+    let allSlugs = serverUseAllMd(markdownDir, tenant);
+    return allSlugs.map((slugArr) => {
+        const normalized = slugArr.filter(Boolean);
+        return { slug: normalized.length ? normalized : undefined };
+    });
+}
+
+export default async function Page(props: any) {
+    const { params } = props;
+    const resolvedParams = typeof params?.then === 'function' ? await params : params;
+    let slugArr = resolvedParams?.slug || [];
+    while (slugArr.length > 1 && slugArr[slugArr.length - 1] === "") slugArr.pop();
+    const tenant = process.env.NEXT_PUBLIC_TENANT || "nx";
+    const { config: rawConfig } = getTenant(tenant as T_Tenant);
+    const config = { ...rawConfig, tenant: tenant as T_Tenant };
+    const filePath = serverUseMDBySlug(slugArr, tenant);
+    if (!filePath || !fs.existsSync(filePath)) notFound();
+    let title = tenant.toUpperCase();
+    let description = "";
+    const md = fs.readFileSync(filePath, "utf-8");
+    const { content, data } = matter(md);
+    if (data.title) title = data.title;
+    if (data.description) description = data.description;
+    const navItems = await serverUseNav();
+    const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme 
+            === 'dark') ? 'dark' : 'light';
+    const themedImage = config?.images?.[themeMode] || null;
+
+    const meta = getMeta({
+        siteName: config.siteName,
+        title,
+        description,
+        url: config.url || "",
+        image: themedImage || data.image,
+    });
+
+    return (
+            <NX config={config} frontmatter={data}>
+                <Header config={config} frontmatter={data} />
+                
+                <Container id="main" maxWidth="lg" 
+                    sx={{ mt: '100px', pb: '90px' }}>
+                    <Box sx={{ width: '100%', display: 'flex', gap: 1 }}>
+                        <Box sx={{ 
+                            display: { xs: 'none', sm: 'flex' }, 
+                            flexDirection: 'column' 
+                        }}>
+                            <Box sx={{ 
+                                flexGrow: 1, 
+                                minHeight: 0, 
+                                minWidth: 200 
+                            }}>
+                                <TreeNav navItems={navItems}/>
+                            </Box>
+                        </Box>
+                        <Box component="main" 
+                            sx={{ 
+                                gridColumn: { lg: '1' }, 
+                                width: '100%', 
+                                minWidth: 0, 
+                                pr: { xs: 2, lg: 3 }, 
+                                pl: { xs: 2, lg: 0 }, 
+                                flexGrow: 1,
+                            }}>
+                            <Account />
+                        </Box>
+                    </Box>
+                </Container>
+                <footer>
+                    <Footer
+                        meta={meta as any}
+                        frontmatter={data}
+                        navItems={navItems as I_NestedNav["navItems"]}
+                    >
+                    </Footer>
+                </footer>
+            </NX>
+    );
+}

--- a/public/echopay/config.json
+++ b/public/echopay/config.json
@@ -25,7 +25,7 @@
             "enabled": false
         },
         "paywall": {
-            "enabled": true
+            "enabled": false
         },
         "designSystem": {
             "themeSwitching": true,


### PR DESCRIPTION
Introduce a dedicated account page and wire up account components.

- Add app/account/page.tsx as the new server page for /account (uses NX layout, TreeNav, Footer and renders <Account />).
- Add a lightweight Paywall/components/Account.tsx component and export it from app/NX/Paywall/index.tsx.
- Refactor User component to accept an onClick prop, use useAuthed, and render a DesignSystem Icon (signin/user) instead of avatar/async logic.
- Update Header to import User from Paywall, route header clicks to /account, and replace previous avatar/action with the new User component.
- Add "use client" directive to useAuthed hook and SignOutBtn for client-side usage.

These changes centralize account-related UI, simplify auth-dependent rendering, and link the header to the new account page.