### PR TITLE
Add SimpleSignIn and update Account/UserSpot

### DIFF
--- a/app/NX/Paywall/components/Account.tsx
+++ b/app/NX/Paywall/components/Account.tsx
@@ -2,15 +2,14 @@
 import React from 'react';
 import { 
     Box,
-    Card,
     CardHeader,
     CardContent,
     CardActions,
-    Typography,
     Button,
  } from '@mui/material';
-import { useAuthed, usePaywall } from '../../Paywall';
+import { useIsAuthed, SimpleSignIn, firebaseLogin, setPaywall } from '../../Paywall';
 import { Icon } from '../../DesignSystem';
+import { useDispatch } from '../../Uberedux';
 
 export interface I_Account {
     onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -18,26 +17,52 @@ export interface I_Account {
 
 export default function Account({ onClick }: I_Account) {
     
-    const paywall = usePaywall();
+    const isAuthed = useIsAuthed();
+    const dispatch = useDispatch();
+
+    const handleSignin = async (email: string, password: string) => {
+        console.log('handleSignin');
+        try {
+            const user = await firebaseLogin(email, password);
+            console.log('handleSignin user', user);
+            // dispatch(setPaywall({ user, authChecked: true }));
+        } catch (error) {
+            // dispatch(setPaywall({ user: null, authChecked: true }));
+            console.log('handleSignin error', error);
+        }
+    }
+
+    if (isAuthed){
+        return <>isAuthed !!</>
+    }
     
-    return (<Card variant='outlined'>
-                <CardHeader 
-                    avatar={<Icon icon="account" color="primary"/>}
-                    title="Name" 
-                    subheader="email"
-                />
-                {/* <CardContent>
-                    <pre>paywall: {JSON.stringify(paywall, null, 2)}</pre>
-                </CardContent> */}
+    return (<Box>
+                
+                {isAuthed && <>
+                    <CardHeader
+                        avatar={<Icon icon="async" color="primary" />}
+                        title={isAuthed ? " (authed)" : " (not authed)"}
+                    />
+                </>}
+
+                <CardContent>
+                {/* <pre>isAuthed: {JSON.stringify(isAuthed, null, 2)}</pre> */}
+                {!isAuthed && <>
+                    <SimpleSignIn onSignIn={handleSignin}/>
+                
+                {/* {!isAuthed && <>
+                    <Button
+                        variant='outlined'
+                        onClick={() => { }}>
+                        Sign Up
+                    </Button>
+                </>} */}
+                </>}
+                </CardContent>
                 <CardActions>
                     <Box sx={{ flexGrow: 1 }} />
-                    <Button 
-                        endIcon={<Icon icon="save" />}
-                        variant='outlined'
-                        onClick={onClick}>
-                        Save
-                    </Button>
+                    
                 </CardActions>
-            </Card>);
+    </Box>);
 
 }

--- a/app/NX/Paywall/components/SimpleSignIn.tsx
+++ b/app/NX/Paywall/components/SimpleSignIn.tsx
@@ -1,0 +1,67 @@
+"use client";
+import React, { useState } from 'react';
+import { IconButton,Button, TextField, Typography, InputAdornment } from '@mui/material';
+import { Icon } from '../../DesignSystem';
+
+export interface I_SimpleSignIn {
+    onSignIn?: (email: string, password: string) => void;
+    [key: string]: any;
+}
+
+export default function SimpleSignIn({ onSignIn}: I_SimpleSignIn) {
+
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+
+    return <>
+            
+            <TextField
+                label="Email"
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                fullWidth
+                required
+                margin="normal"
+            />
+            <TextField
+                label="Password"
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                variant='outlined'
+                onChange={e => setPassword(e.target.value)}
+                fullWidth
+                required
+                margin="normal"
+                InputProps={{
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <IconButton
+                                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                                onClick={() => setShowPassword((show) => !show)}
+                                edge="end"
+                            >
+                                <Icon color={"primary"} icon={showPassword ? 'hide' : 'show'} />
+                            </IconButton>
+                        </InputAdornment>
+                    ),
+                }}
+            />
+            <Typography sx={{ my: 1 }} color="primary">
+                {error}
+            </Typography>
+            <Button
+                fullWidth
+                type="submit"
+                endIcon={<Icon icon="signin" />}
+                variant="outlined"
+                sx={{ mx: 0 }}
+                onClick={() => onSignIn && onSignIn(email, password)}
+            >
+                Sign In
+            </Button>
+        </>
+    
+}

--- a/app/NX/Paywall/components/User.tsx
+++ b/app/NX/Paywall/components/User.tsx
@@ -1,17 +1,14 @@
 "use client";
-
 import React from 'react';
-import { IconButton } from '@mui/material';
+import { IconButton, Box, Avatar } from '@mui/material';
 import { useIsAuthed } from '../../Paywall';
 import { Icon } from '../../DesignSystem';
-
 
 export interface I_UserSpot {
     onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export default function UserSpot({ onClick }: I_UserSpot) {
-    
     const isAuthed = useIsAuthed();
     const [hide, setHide] = React.useState(false);
 
@@ -25,7 +22,7 @@ export default function UserSpot({ onClick }: I_UserSpot) {
 
     return (
         <IconButton onClick={onClick} color="primary">
-            <Icon icon="async" />
+            <Icon icon="account" />
         </IconButton>
     );
 }

--- a/app/NX/Paywall/index.tsx
+++ b/app/NX/Paywall/index.tsx
@@ -1,6 +1,7 @@
 
 import Paywall from "./Paywall";
 import SignIn from './components/SignIn';
+import SimpleSignIn from './components/SimpleSignIn';
 import UserSpot from './components/UserSpot';
 import Account from './components/Account';
 import SignOutBtn from './components/SignOutBtn';
@@ -15,6 +16,7 @@ export {
     Paywall,
     Account,
     SignIn,
+    SimpleSignIn,
     SignOutBtn,
     setPaywall,
     useAuthed,

--- a/public/listingslab/config.json
+++ b/public/listingslab/config.json
@@ -4,7 +4,7 @@
     "description": "Coming soon",
     "url": "https://listingslab.com",
     "owner": {
-        "name": "Goldlabel",
+        "name": "Milky",
         "email": "goldlabel.apps@gmail.com"
     },
     "favicon": "/listingslab/png/favicon.png",
@@ -21,7 +21,7 @@
             "enabled": true
         },
         "paywall": {
-            "enabled": true
+            "enabled": false
         },
         "async": {
             "enabled": false


### PR DESCRIPTION
Introduce a SimpleSignIn component and wire it into the Account UI, switching Account to use useIsAuthed and a firebaseLogin handler (with dispatch setup for setPaywall commented). Update UserSpot to use a client-side effect to hide itself on the /account route and change the displayed icon. Export SimpleSignIn from the Paywall index and adjust imports/JSX in Account to render the new sign-in flow. Small cleanup of unused imports and UI adjustments across the modified files.