### PR TITLE
Paywall: account UI updates and init action

### DIFF
--- a/app/NX/Paywall/actions/initPaywall.tsx
+++ b/app/NX/Paywall/actions/initPaywall.tsx
@@ -1,0 +1,13 @@
+import type { Dispatch } from 'redux';
+import { setUbereduxKey } from '../../Uberedux';
+
+
+export const initPaywall = () =>
+        async (dispatch: Dispatch, getState: () => any) => {
+            try {
+
+            } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                dispatch(setUbereduxKey({ key: 'error', value: msg }));
+            }
+        };

--- a/app/NX/Paywall/components/Account.tsx
+++ b/app/NX/Paywall/components/Account.tsx
@@ -4,19 +4,17 @@ import {
     Box,
     CardHeader,
     CardContent,
-    Button,
- } from '@mui/material';
+} from '@mui/material';
 import { 
     useUID,
     useIsAuthed, 
     SimpleSignIn, 
     firebaseLogin, 
     usePaywall,
-    firebaseLogout,
     setPaywall,
     AccountCard,
  } from '../../Paywall';
-import { Icon, setFeedback } from '../../DesignSystem';
+import { Icon } from '../../DesignSystem';
 import { useDispatch } from '../../Uberedux';
 
 export interface I_Account {
@@ -29,21 +27,7 @@ export default function Account({ onClick }: I_Account) {
     const uid = useUID();
     const dispatch = useDispatch();
 
-    // Wait for authChecked before rendering
     if (!paywall?.authChecked) return null;
-
-    const handleSignOut = async () => {
-        try {
-            const user = await firebaseLogout();
-            dispatch(setFeedback({
-                severity: 'success',
-                title: 'Signed out successfully',
-            }))
-        } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error);
-            dispatch(setPaywall('error', errorMsg));
-        }
-    }
 
     const handleSignin = async (email: string, password: string) => {
         try {

--- a/app/NX/Paywall/components/AccountCard.tsx
+++ b/app/NX/Paywall/components/AccountCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
 import { 
     Badge,
     Avatar,
@@ -7,20 +8,17 @@ import {
     CardHeader,
     CardActions,
     Button,
+    IconButton,
 } from '@mui/material';
 import { usePaywall, setPaywall, subscribeAccount, firebaseLogout } from '../../Paywall';
 import { useDispatch } from '../../Uberedux';
 import { Icon } from '../../DesignSystem';
 
-export interface I_AccountCard {
-    onClick?: React.MouseEventHandler<HTMLButtonElement>;
-}
-
-export default function AccountCard({ onClick }: I_AccountCard) {
+export default function AccountCard() {
 
     const dispatch = useDispatch();
     const paywall = usePaywall();
-    const { account, accountSubscribing } = paywall || {};
+    const { account } = paywall || {};
     const {
         avatar,
         level,
@@ -28,38 +26,48 @@ export default function AccountCard({ onClick }: I_AccountCard) {
         email,
     } = account || {}; 
 
+    const [open, setOpen] = React.useState(false);
+
+    const handleOpen = () => setOpen(true);
+    const handleClose = () => setOpen(false);
+
     const onSignOut = async () => {
         await firebaseLogout();
         dispatch(setPaywall('user', null));
         dispatch(setPaywall('account', null));
+        setOpen(false);
     }
     
-    React.useEffect(() => {
-        if (!account && !accountSubscribing) {
-            dispatch(setPaywall('accountSubscribing', true));
-            dispatch(subscribeAccount());
-        };
-    }, [account, accountSubscribing, dispatch]);
-
     return (<>
-            <Box>
-                <CardHeader
-                    title={name || null}
-                    subheader={email || null}
-                    avatar={<Badge badgeContent={level}>
-                                <Avatar src={avatar} />
-                            </Badge>}
-                    />
-                    <CardActions>
-                        <Button 
-                            endIcon={<Icon icon="signout" />}
-                            variant="outlined" 
-                            onClick={onSignOut}>
-                                Sign out
-                            </Button>
-                    </CardActions>
-            </Box>
-            {/* <pre>account: {JSON.stringify(account, null, 2)}</pre> */}
-        </>
+        <Box>
+            <CardHeader
+                title={name || null}
+                subheader={email || null}
+                avatar={<Badge badgeContent={level}>
+                    <Avatar src={avatar} />
+                </Badge>}
+                action={<IconButton color="primary" onClick={handleOpen}>
+                    <Icon icon="signout" />
+                </IconButton>}
+            />
+        </Box>
+        <Dialog open={open} onClose={handleClose}>
+            <DialogTitle>Confirm Sign Out</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Are you sure you want to sign out?
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={onSignOut} color="primary" autoFocus>
+                    Sign Out
+                </Button>
+            </DialogActions>
+        </Dialog>
+        {/* <pre>paywall: {JSON.stringify(paywall, null, 2)}</pre> */}
+    </>
     );
 }

--- a/app/NX/Paywall/components/RequireAuth.tsx
+++ b/app/NX/Paywall/components/RequireAuth.tsx
@@ -49,7 +49,7 @@ export default function RequireAuth({ children, config }: { children: React.Reac
                     photoURL: photoURL ?? null
                 };
             }
-            dispatch(setPaywall("firebaseUser", safeUser));
+            dispatch(setPaywall("user", safeUser));
             setLoading(false);
         });
         return () => unsubscribe();

--- a/app/NX/Paywall/components/SimpleSignIn.tsx
+++ b/app/NX/Paywall/components/SimpleSignIn.tsx
@@ -71,7 +71,6 @@ export default function SimpleSignIn({ onSignIn}: I_SimpleSignIn) {
                 {error}
             </Typography>
             <Button
-                fullWidth
                 type="submit"
                 endIcon={<Icon icon="signin" />}
                 variant="outlined"

--- a/app/NX/Paywall/components/UserSpot.tsx
+++ b/app/NX/Paywall/components/UserSpot.tsx
@@ -1,27 +1,39 @@
 "use client";
 import React from 'react';
-import { IconButton } from '@mui/material';
+import { IconButton, Avatar } from '@mui/material';
 import { Icon } from '../../DesignSystem';
+import { usePaywall, subscribeAccount, setPaywall } from '../../Paywall';
+import { useDispatch } from '../../Uberedux';
 
 export interface I_UserSpot {
     onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 export default function UserSpot({ onClick }: I_UserSpot) {
-    
-    const [hide, setHide] = React.useState(false);
+
+    const paywall = usePaywall();
+    const account = paywall ? paywall.account : null;
+    const accountSubscribing = paywall ? paywall.accountSubscribing : null;
+    const dispatch = useDispatch();
 
     React.useEffect(() => {
-        if (window.location.pathname === "/account") {
-            setHide(true);
-        }
-    }, []);
+        if (!account && !accountSubscribing) {
+            dispatch(setPaywall('accountSubscribing', true));
+            dispatch(subscribeAccount());
+        };
+    }, [account, accountSubscribing, dispatch]);
 
-    if (hide) return null;
-
+    if (typeof window !== "undefined" && window.location.pathname === "/account") {
+        return null;
+    }
+    
     return (
         <IconButton onClick={onClick} color="primary">
-            <Icon icon="async" />
+            {account ? (
+                <Avatar alt={account.name} src={account.avatar} />
+            ) : (
+                <Icon icon="async" />
+            )}
         </IconButton>
     );
 }

--- a/app/NX/Virus/Virus.tsx
+++ b/app/NX/Virus/Virus.tsx
@@ -7,12 +7,8 @@ import {
   WhatsappShareButton,
   TwitterShareButton,
 } from 'react-share';
-import { Tooltip, Box, Typography, ButtonBase, Popover, Dialog
-
-  
- } from '@mui/material';
+import { Tooltip, Box, Typography, ButtonBase, Popover, Dialog} from '@mui/material';
 import { Icon } from '../../NX/DesignSystem';
-import { Forward } from '../../NX/Virus';
 
 export default function Virus({
   meta,
@@ -76,7 +72,12 @@ export default function Virus({
         <Box id="virus" sx={{ p: 1 }}>
 
           <Box sx={{  }}>
+            <pre>title: {JSON.stringify(title, null, 2)}</pre>
+            <pre>description: {JSON.stringify(description, null, 2)}</pre>
+            <pre>image: {JSON.stringify(image, null, 2)}</pre>
+
             <Box sx={{ display: 'flex' }}>
+              
               <Box sx={{m:1, mr: 2}}>
                 <ButtonBase
                   onClick={e => {
@@ -100,9 +101,6 @@ export default function Virus({
                     </Typography>
                 </ButtonBase>
               </Box>
-              <Box sx={{ m: 1 }}>
-                  <Forward />
-                </Box>
               
             </Box>
 
@@ -112,17 +110,12 @@ export default function Virus({
                   <Icon icon="twitter" color={'primary'} />
                 </TwitterShareButton>
               </Tooltip>
-            </Box>
-
-            <Box sx={{ m: 1 }}>
+            
               <Tooltip title="Facebook" placement="top">
                 <FacebookShareButton url={url} >
                   <Icon icon="facebook" color={'primary'} />
                 </FacebookShareButton>
               </Tooltip>
-            </Box>
-
-            <Box sx={{ m: 1 }}>
               <Tooltip title="Share on LinkedIn" placement="top">
                 <LinkedinShareButton
                   url={url}
@@ -131,9 +124,6 @@ export default function Virus({
                   <Icon icon="linkedin" color={'primary'} />
                 </LinkedinShareButton>
               </Tooltip>
-            </Box>
-
-            <Box sx={{ m: 1 }}>
               <Tooltip title="Share on WhatsApp" placement="top">
                 <WhatsappShareButton
                   url={url}

--- a/app/NX/Virus/Virus.tsx
+++ b/app/NX/Virus/Virus.tsx
@@ -7,7 +7,12 @@ import {
   WhatsappShareButton,
   TwitterShareButton,
 } from 'react-share';
-import { Tooltip, Box, Typography, ButtonBase, Popover, Dialog} from '@mui/material';
+import { 
+  CardMedia,
+  CardHeader,
+  Skeleton,
+  Box, Typography, ButtonBase, Popover, Dialog,
+} from '@mui/material';
 import { Icon } from '../../NX/DesignSystem';
 
 export default function Virus({
@@ -20,6 +25,7 @@ export default function Virus({
   let title = meta?.title || '';
   let description = meta?.description || '';
   let image = '';
+  let icon = '';
   const [copied, setCopied] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
   const [url, setUrl] = React.useState('');
@@ -29,9 +35,13 @@ export default function Virus({
     title = frontmatter.title || title;
     description = frontmatter.description || description;
     image = frontmatter.image || '';
+    icon = frontmatter.icon || '';
   } else if (meta) {
     image = meta.openGraph?.images?.[0] || '';
   }
+
+  // Preloader state for image
+  const [imgLoaded, setImgLoaded] = React.useState(false);
 
   React.useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -50,6 +60,8 @@ export default function Virus({
       <ButtonBase onClick={() => setOpen(true)} sx={{ }}>
         <Icon icon="share" color="primary" />
       </ButtonBase>
+
+      
       <Popover
         open={copied}
         anchorEl={anchorEl}
@@ -67,14 +79,36 @@ export default function Virus({
           </Typography>
         </Box>
       </Popover>
-      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth>
+
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
 
         <Box id="virus" sx={{ p: 1 }}>
-
           <Box sx={{  }}>
-            <pre>title: {JSON.stringify(title, null, 2)}</pre>
-            <pre>description: {JSON.stringify(description, null, 2)}</pre>
-            <pre>image: {JSON.stringify(image, null, 2)}</pre>
+
+            
+
+            {/* Show CardMedia with Skeleton preloader if image is a non-empty string */}
+            {typeof image === 'string' && image.trim() ? (
+              <Box sx={{ width: '100%', maxWidth: 400, m: 2 }}>
+                {!imgLoaded && (
+                  <Skeleton variant="rectangular" width="100%" height={200} />
+                )}
+                <CardMedia
+                  component="img"
+                  image={image}
+                  alt={title || 'image'}
+                  sx={{ display: imgLoaded ? 'block' : 'none', width: '100%', height: 200, objectFit: 'cover', borderRadius: 2 }}
+                  onLoad={() => setImgLoaded(true)}
+                  onError={() => setImgLoaded(true)}
+                />
+              </Box>
+            ) : null}
+
+            <CardHeader
+              title={title || 'No title'}
+              subheader={description || 'No description'}
+              avatar={icon ? <Icon icon={icon as any} color="primary" /> : null}
+            />
 
             <Box sx={{ display: 'flex' }}>
               
@@ -105,37 +139,50 @@ export default function Virus({
             </Box>
 
             <Box sx={{ m: 1 }}>
-              <Tooltip title="X/Twitter" placement="top">
-                <TwitterShareButton url={url}>
+              <TwitterShareButton url={url}>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Icon icon="twitter" color={'primary'} />
-                </TwitterShareButton>
-              </Tooltip>
-            
-              <Tooltip title="Facebook" placement="top">
-                <FacebookShareButton url={url} >
+                  <Typography variant="body1" sx={{ ml: 1 }}>
+                    X/Twitter
+                  </Typography>
+                </Box>
+              </TwitterShareButton>
+
+              <FacebookShareButton url={url} >
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Icon icon="facebook" color={'primary'} />
-                </FacebookShareButton>
-              </Tooltip>
-              <Tooltip title="Share on LinkedIn" placement="top">
-                <LinkedinShareButton
-                  url={url}
-                  summary={description}
-                >
+                  <Typography variant="body1" sx={{ ml: 1 }}>
+                    Facebook
+                  </Typography>
+                </Box>
+              </FacebookShareButton>
+
+              <LinkedinShareButton
+                url={url}
+                summary={description}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Icon icon="linkedin" color={'primary'} />
-                </LinkedinShareButton>
-              </Tooltip>
-              <Tooltip title="Share on WhatsApp" placement="top">
-                <WhatsappShareButton
-                  url={url}
-                  separator=" - "
-                >
+                  <Typography variant="body1" sx={{ ml: 1 }}>
+                    LinkedIn
+                  </Typography>
+                </Box>
+              </LinkedinShareButton>
+
+              <WhatsappShareButton
+                url={url}
+                separator=" - "
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Icon icon="whatsapp" color={'primary'} />
-                </WhatsappShareButton>
-              </Tooltip>
+                  <Typography variant="body1" sx={{ ml: 1 }}>
+                    WhatsApp
+                  </Typography>
+                </Box>
+              </WhatsappShareButton>
+
             </Box>
-            
           </Box>
-          
         </Box>
       </Dialog>
     </>

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -42,14 +42,16 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     const themeMode: 'light' | 'dark' = 'light';
     let title = config.siteName || "";
     let description = config.description || "";
-    let image = config.images?.[themeMode] || "";
+    let image = config.images?.[themeMode] || config.images?.light || "";
     if (filePath && fs.existsSync(filePath)) {
         const md = fs.readFileSync(filePath, "utf-8");
         const { data } = matter(md);
         if (data?.title) title = data.title;
         if (data?.description) description = data.description;
         if (data?.url) url = data.url;
-        if (data?.image) image = data.image;
+        if (typeof data?.image === 'string' && data.image.trim()) {
+            image = data.image;
+        }
     }
     const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
     const pageUrl = url.replace(/\/$/, "") + (slugPath ? `/${slugPath}` : "");
@@ -92,14 +94,15 @@ export default async function Page(props: any) {
     const navItems = await serverUseNav();
     const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme 
             === 'dark') ? 'dark' : 'light';
-    const themedImage = config?.images?.[themeMode] || null;
+    const themedImage = config?.images?.[themeMode] || config?.images?.light || null;
 
+    // Use data.image if it's a non-empty string, otherwise fallback to themedImage
     const meta = getMeta({
         siteName: config.siteName,
         title,
         description,
         url: config.url || "",
-        image: themedImage || data.image,
+        image: (typeof data.image === 'string' && data.image.trim()) ? data.image : themedImage,
     });
 
     return (

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -43,6 +43,7 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     let title = config.siteName || "";
     let description = config.description || "";
     let image = config.images?.[themeMode] || config.images?.light || "";
+    let icon = null;
     if (filePath && fs.existsSync(filePath)) {
         const md = fs.readFileSync(filePath, "utf-8");
         const { data } = matter(md);
@@ -51,6 +52,9 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
         if (data?.url) url = data.url;
         if (typeof data?.image === 'string' && data.image.trim()) {
             image = data.image;
+        }
+        if (typeof data?.icon === 'string' && data.icon.trim()) {
+            icon = data.icon;
         }
     }
     const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
@@ -91,6 +95,7 @@ export default async function Page(props: any) {
     const { content, data } = matter(md);
     if (data.title) title = data.title;
     if (data.description) description = data.description;
+    const icon = (typeof data.icon === 'string' && data.icon.trim()) ? data.icon : null;
     const navItems = await serverUseNav();
     const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme 
             === 'dark') ? 'dark' : 'light';

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -40,14 +40,16 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     const themeMode: 'light' | 'dark' = 'light';
     let title = config.siteName || "";
     let description = config.description || "";
-    let image = config.images?.[themeMode] || "";
+    let image = config.images?.[themeMode] || config.images?.light || "";
     if (filePath && fs.existsSync(filePath)) {
         const md = fs.readFileSync(filePath, "utf-8");
         const { data } = matter(md);
         if (data?.title) title = data.title;
         if (data?.description) description = data.description;
         if (data?.url) url = data.url;
-        if (data?.image) image = data.image;
+        if (typeof data?.image === 'string' && data.image.trim()) {
+            image = data.image;
+        }
     }
     const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
     const pageUrl = url.replace(/\/$/, "") + (slugPath ? `/${slugPath}` : "");
@@ -90,14 +92,15 @@ export default async function Page(props: any) {
     const navItems = await serverUseNav();
     const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme 
             === 'dark') ? 'dark' : 'light';
-    const themedImage = config?.images?.[themeMode] || null;
+    const themedImage = config?.images?.[themeMode] || config?.images?.light || null;
 
+    // Use data.image if it's a non-empty string, otherwise fallback to themedImage
     const meta = getMeta({
         siteName: config.siteName,
         title,
         description,
         url: config.url || "",
-        image: themedImage || data.image,
+        image: (typeof data.image === 'string' && data.image.trim()) ? data.image : themedImage,
     });
 
     return (

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -41,6 +41,7 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     let title = config.siteName || "";
     let description = config.description || "";
     let image = config.images?.[themeMode] || config.images?.light || "";
+    let icon = null;
     if (filePath && fs.existsSync(filePath)) {
         const md = fs.readFileSync(filePath, "utf-8");
         const { data } = matter(md);
@@ -49,6 +50,9 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
         if (data?.url) url = data.url;
         if (typeof data?.image === 'string' && data.image.trim()) {
             image = data.image;
+        }
+        if (typeof data?.icon === 'string' && data.icon.trim()) {
+            icon = data.icon;
         }
     }
     const slugPath = Array.isArray(slugArr) && slugArr.length ? slugArr.join("/") : "";
@@ -89,6 +93,7 @@ export default async function Page(props: any) {
     const { content, data } = matter(md);
     if (data.title) title = data.title;
     if (data.description) description = data.description;
+    const icon = (typeof data.icon === 'string' && data.icon.trim()) ? data.icon : null;
     const navItems = await serverUseNav();
     const themeMode: 'light' | 'dark' = (config?.cartridges?.designSystem?.defaultTheme 
             === 'dark') ? 'dark' : 'light';

--- a/app/nx-admin/page.tsx
+++ b/app/nx-admin/page.tsx
@@ -16,8 +16,10 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     const defaultThemeMode: 'light' | 'dark' = defaultThemeModeRaw === 'light' 
         || defaultThemeModeRaw === 'dark' ? defaultThemeModeRaw : 'light';
     const imagesObj: { light?: string; dark?: string } | undefined = config.images;
-    const imageRaw = imagesObj && defaultThemeMode in imagesObj ? imagesObj[defaultThemeMode] : undefined;
-    const image: string = imageRaw || config.siteName;
+    const imageRaw = imagesObj && defaultThemeMode in imagesObj ? imagesObj[defaultThemeMode] : imagesObj?.light;
+    let image: string = imageRaw || config.siteName;
+    // If you have a data.image from frontmatter, use it if non-empty string (not available here, but for consistency)
+    // image = (typeof data?.image === 'string' && data.image.trim()) ? data.image : imageRaw;
     const url = `${getBaseurl()}/nx-admin`;
 
     return {

--- a/app/nx-admin/page.tsx
+++ b/app/nx-admin/page.tsx
@@ -20,6 +20,8 @@ export async function generateMetadata({ params }: { params: any }): Promise<Met
     let image: string = imageRaw || config.siteName;
     // If you have a data.image from frontmatter, use it if non-empty string (not available here, but for consistency)
     // image = (typeof data?.image === 'string' && data.image.trim()) ? data.image : imageRaw;
+    // Icon fallback logic (not available here, but for consistency)
+    let icon = null;
     const url = `${getBaseurl()}/nx-admin`;
 
     return {

--- a/public/edtech/manifest.json
+++ b/public/edtech/manifest.json
@@ -14,12 +14,6 @@
       "type": "image/png",
       "sizes": "180x180",
       "purpose": "any maskable"
-    },
-    {
-      "src": "/edtech/svg/favicon.svg",
-      "type": "image/svg+xml",
-      "sizes": "512x512",
-      "purpose": "any"
     }
   ]
 }

--- a/public/listingslab/markdown/how-to-use/index.md
+++ b/public/listingslab/markdown/how-to-use/index.md
@@ -1,7 +1,7 @@
 ---
 order: 40
 slug: /how-to-use
-title: 🍀 How to use
+title: How to use
 icon: activities
 description: Different ways to consume cannabis, including smoking, vaping, and edibles
 tags: UK law, access routes, prescriptions, clinics, compliance, risks.


### PR DESCRIPTION
Add a new initPaywall action (with error handling). Update account-related components: remove previous inline sign-out handler/feedback in Account, add a confirmation Dialog for sign-out in AccountCard (IconButton + Dialog), simplify AccountCard props and clear user/account on logout. RequireAuth now stores the auth payload under the 'user' key instead of 'firebaseUser'. SimpleSignIn: remove fullWidth on submit Button. UserSpot: show Avatar when account exists, trigger account subscription if missing, and hide on the /account route. Also small docs change: remove emoji from the "How to use" title. These changes improve sign-out UX, consolidate user state key, and ensure account data is subscribed when needed.