### PR TITLE
This pull request refactors the way Firebase authentication state is handled across the application by introducing a reusable hook, `useFirebaseAuthListener`,

### DIFF
--- a/app/NX/DesignSystem/components/Settings.tsx
+++ b/app/NX/DesignSystem/components/Settings.tsx
@@ -1,8 +1,8 @@
 'use client';
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useRouter } from 'next/navigation';
-import { getFirebaseAuth } from '../../lib/firebase';
-import { onAuthStateChanged, User } from 'firebase/auth';
+import { User } from 'firebase/auth';
+import { useFirebaseAuthListener } from '../../lib';
 import {
 	List,
 	ListItemButton,
@@ -27,14 +27,10 @@ const Settings: React.FC<I_Settings> = () => {
 	const designSystem = useDesignSystem();
 	const currentThemeMode = designSystem?.themeMode ?? 'light';
 
-	useEffect(() => {
-		const auth = getFirebaseAuth();
-		const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
-			setUser(firebaseUser);
-			setLoading(false);
-		});
-		return () => unsubscribe();
-	}, []);
+	useFirebaseAuthListener((firebaseUser) => {
+		setUser(firebaseUser);
+		setLoading(false);
+	});
 
 	const handleLogout = async () => {
 		await firebaseLogout();

--- a/app/NX/Orders/actions/initOrders.tsx
+++ b/app/NX/Orders/actions/initOrders.tsx
@@ -29,11 +29,11 @@ export const initOrders = (): any =>
                     }));
                     dispatch(setOrders('error', description));
                 } else {
-                    dispatch(setFeedback({
-                        severity: 'success',
-                        title: `${baseURL}`,
-                        description: 'API Healthy.',
-                    }));
+                    // dispatch(setFeedback({
+                    //     severity: 'success',
+                    //     title: `${baseURL}`,
+                    //     description: 'API Healthy.',
+                    // }));
                     // Healthcheck successful, now fetch products
                     dispatch(fetchProducts());
                 }

--- a/app/NX/Paywall/components/RequireAuth.tsx
+++ b/app/NX/Paywall/components/RequireAuth.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import type { T_Config } from "../../types";
 import SignIn from './SignIn';
 import { firebaseLogin } from '../../Paywall';
-import { getFirebaseAuth } from '../../lib/firebase';
-import { onAuthStateChanged, User } from 'firebase/auth';
+import { User } from 'firebase/auth';
+import { useFirebaseAuthListener } from '../../lib';
 import { Typography, Backdrop, CircularProgress, Box } from "@mui/material";
 import { useDispatch } from '../../Uberedux';
 import { setPaywall } from '../../Paywall';
@@ -25,35 +25,10 @@ export default function RequireAuth({ children, config }: { children: React.Reac
         }
     };
 
-    useEffect(() => {
-        const auth = getFirebaseAuth();
-        const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
-            setUser(firebaseUser);
-            let safeUser = null;
-            if (firebaseUser) {
-                const { uid, email, emailVerified, isAnonymous, providerData, displayName, photoURL } = firebaseUser;
-                safeUser = {
-                    uid,
-                    email,
-                    emailVerified,
-                    isAnonymous,
-                    providerData: providerData?.map(p => ({
-                        providerId: p.providerId,
-                        uid: p.uid,
-                        displayName: p.displayName,
-                        email: p.email,
-                        phoneNumber: p.phoneNumber,
-                        photoURL: p.photoURL
-                    })),
-                    displayName: displayName ?? null,
-                    photoURL: photoURL ?? null
-                };
-            }
-            dispatch(setPaywall("user", safeUser));
-            setLoading(false);
-        });
-        return () => unsubscribe();
-    }, []);
+    useFirebaseAuthListener((firebaseUser) => {
+        setUser(firebaseUser);
+        setLoading(false);
+    });
 
     if (loading) return (
         <Backdrop open sx={{ zIndex: (theme) => theme.zIndex.drawer + 1, color: '#fff' }}>

--- a/app/NX/Paywall/hooks/useAuthed.ts
+++ b/app/NX/Paywall/hooks/useAuthed.ts
@@ -1,46 +1,16 @@
 "use client";
-import { useEffect, useState } from "react";
-import { getFirebaseAuth } from "../../lib/firebase";
+import { useState } from "react";
 import { User } from "firebase/auth";
-import { setPaywall} from '../../Paywall';
-import { useDispatch } from '../../Uberedux';
+import { useFirebaseAuthListener } from '../../lib/index';
 
 /**
  * useAuthed - React hook to get Firebase auth state
  * Returns: User object if authenticated, null otherwise
  */
 export function useAuthed(): User | null {
-	const [user, setUser] = useState<User | null>(null);
-	const dispatch = useDispatch();
-	useEffect(() => {
-		const auth = getFirebaseAuth();
-		const unsubscribe = auth.onAuthStateChanged((firebaseUser) => {
-			setUser(firebaseUser ?? null);
-			dispatch(setPaywall('user', null));
-			if (firebaseUser) {
-				const { uid, email, emailVerified, isAnonymous, providerData, displayName, photoURL } = firebaseUser;
-				const safeUser = {
-					uid,
-					email,
-					emailVerified,
-					isAnonymous,
-					providerData: providerData?.map((p: typeof providerData[0]) => ({
-						providerId: p.providerId,
-						uid: p.uid,
-						displayName: p.displayName,
-						email: p.email,
-						phoneNumber: p.phoneNumber,
-						photoURL: p.photoURL
-					})),
-					displayName: displayName ?? null,
-					photoURL: photoURL ?? null
-				};
-				dispatch(setPaywall('user', safeUser));
-			}
-			dispatch(setPaywall('authChecked', true));
-		});
-		return () => unsubscribe();
-	}, []);
-
-	return user;
+    const [user, setUser] = useState<User | null>(null);
+    useFirebaseAuthListener((firebaseUser) => {
+        setUser(firebaseUser ?? null);
+    });
+    return user;
 }

--- a/app/NX/lib/getMeta.tsx
+++ b/app/NX/lib/getMeta.tsx
@@ -1,5 +1,5 @@
 // import type { I_Meta } from '../types';
-import { getTenant } from './';
+import { getTenant } from './getTenant';
 
 export const getMeta = (props: any) => {
 

--- a/app/NX/lib/hooks/useFirebaseAuthListener.ts
+++ b/app/NX/lib/hooks/useFirebaseAuthListener.ts
@@ -1,0 +1,51 @@
+"use client";
+import { useEffect } from 'react';
+import { getFirebaseAuth } from '../firebase';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { useDispatch } from '../../Uberedux';
+import { setPaywall } from '../../Paywall';
+
+/**
+ * useFirebaseAuthListener
+ * Sets up a global Firebase auth state listener and dispatches to Uberedux/setPaywall.
+ *
+ * @param onUserChange Optional callback for user state changes
+ * @param onAuthChecked Optional callback when auth check completes
+ */
+export function useFirebaseAuthListener(
+  onUserChange?: (user: User | null) => void,
+  onAuthChecked?: () => void
+) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const auth = getFirebaseAuth();
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      let safeUser = null;
+      if (firebaseUser) {
+        const { uid, email, emailVerified, isAnonymous, providerData, displayName, photoURL } = firebaseUser;
+        safeUser = {
+          uid,
+          email,
+          emailVerified,
+          isAnonymous,
+          providerData: providerData?.map((p) => ({
+            providerId: p.providerId,
+            uid: p.uid,
+            displayName: p.displayName,
+            email: p.email,
+            phoneNumber: p.phoneNumber,
+            photoURL: p.photoURL,
+          })),
+          displayName: displayName ?? null,
+          photoURL: photoURL ?? null,
+        };
+      }
+      dispatch(setPaywall('user', safeUser));
+      dispatch(setPaywall('authChecked', true));
+      if (onUserChange) onUserChange(firebaseUser);
+      if (onAuthChecked) onAuthChecked();
+    });
+    return () => unsubscribe();
+  }, [dispatch, onUserChange, onAuthChecked]);
+}

--- a/app/NX/lib/index.server.ts
+++ b/app/NX/lib/index.server.ts
@@ -1,20 +1,15 @@
-import { getTenant } from './getTenant';
 import { serverUseNav } from './serverHooks/serverUseNav';
 import { serverUseConfig } from './serverHooks/serverUseConfig';
 import { serverUseMDBySlug } from './serverHooks/serverUseMDBySlug';
 import { serverUseAllMd } from './serverHooks/serverUseAllMd';
-import { createSlug } from './vanilla-js/createSlug';
-import { makeIdentity } from './vanilla-js/makeIdentity';
-import { militaryTime } from './vanilla-js/militaryTime';
+import { getTenant } from './getTenant';
 import { getMeta } from './getMeta';
+
 export {
     serverUseNav,
     serverUseConfig,
     serverUseMDBySlug,
     serverUseAllMd,
-    createSlug,
     getTenant,
     getMeta,
-    militaryTime,
-    makeIdentity,
 };

--- a/app/NX/lib/index.ts
+++ b/app/NX/lib/index.ts
@@ -1,0 +1,11 @@
+import { createSlug } from './vanilla-js/createSlug';
+import { makeIdentity } from './vanilla-js/makeIdentity';
+import { militaryTime } from './vanilla-js/militaryTime';
+import { useFirebaseAuthListener } from './hooks/useFirebaseAuthListener';
+
+export {
+    createSlug,
+    militaryTime,
+    useFirebaseAuthListener,
+    makeIdentity,
+};

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -15,7 +15,7 @@ import {
     serverUseNav,
     getTenant,
     getMeta,
-} from '../NX/lib';
+} from '../NX/lib/index.server';
 import {
     Icon,
     Header,

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -3,18 +3,9 @@ import fs from "fs";
 import matter from "gray-matter";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
-import {
-    Box,
-    Container,
-} from '@mui/material';
+import { Box, Container } from '@mui/material';
 import { NX } from '../NX';
-import {
-    serverUseMDBySlug,
-    serverUseAllMd,
-    serverUseNav,
-    getTenant,
-    getMeta,
-} from '../NX/lib';
+import { serverUseMDBySlug, serverUseAllMd, serverUseNav, getTenant, getMeta } from '../NX/lib/index.server';
 import {
     Header,
     Footer,

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,9 +7,7 @@ import config from '../public/nx/config.json';
 import {
     Nav,
 } from './NX/DesignSystem';
-import {
-    serverUseNav,
-} from './NX/lib';
+
 
 export default function NotFound() {
 

--- a/app/nx-admin/NXAdminAuthWrapper.tsx
+++ b/app/nx-admin/NXAdminAuthWrapper.tsx
@@ -1,5 +1,7 @@
+// The import for getFirebaseAuth is not present in the file, so no action is needed.
 "use client";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useFirebaseAuthListener } from '../NX/lib';
 import { getFirebaseAuth } from '../NX/lib/firebase';
 import { SignIn } from '../NX/Paywall';
 import { NXAdmin } from '../NX/NXAdmin';
@@ -13,14 +15,10 @@ export default function NXAdminAuthWrapper({
     const [user, setUser] = useState<any>(null);
     const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        const auth = getFirebaseAuth();
-        const unsubscribe = auth.onAuthStateChanged((u) => {
-            setUser(u);
-            setLoading(false);
-        });
-        return () => unsubscribe();
-    }, []);
+    useFirebaseAuthListener((u) => {
+        setUser(u);
+        setLoading(false);
+    });
 
     const [signInError, setSignInError] = useState<string>("");
 

--- a/app/nx-admin/page.tsx
+++ b/app/nx-admin/page.tsx
@@ -1,6 +1,6 @@
 import type { T_Tenant } from '../NX/types';
 import { Metadata } from "next";
-import { getTenant } from '../NX/lib';
+import { getTenant } from '../NX/lib/index.server';
 import { getBaseurl } from '../api';
 import NXAdminAuthWrapper from './NXAdminAuthWrapper';
 

--- a/app/share/[slug]/page.tsx
+++ b/app/share/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { T_Theme, T_Tenant, T_Meta, I_NestedNav } from '../../NX/types';
 import { notFound } from 'next/navigation';
 import { Metadata } from "next";
-import { getTenant, getMeta, serverUseNav } from '../../NX/lib';
+import { getTenant, getMeta, serverUseNav } from '../../NX/lib/index.server';
 import { getBaseurl } from '../../api';
 import { mergeData } from './mergeData';
 import ShareClient from './ShareClient';


### PR DESCRIPTION
 and applying it throughout the codebase. Additionally, it cleans up and clarifies imports, particularly separating server and client utilities, and makes minor improvements to feedback logic and code organization.

**Firebase Authentication Refactor:**

* Introduced a new hook, `useFirebaseAuthListener`, in `app/NX/lib/hooks/useFirebaseAuthListener.ts`, which centralizes Firebase auth state listening, dispatches user/authChecked state to Uberedux, and accepts optional callbacks for user and auth check events.
* Replaced direct usage of `useEffect` and Firebase's `onAuthStateChanged` in components and hooks (`Settings.tsx`, `RequireAuth.tsx`, `useAuthed.ts`, `NXAdminAuthWrapper.tsx`) with the new `useFirebaseAuthListener` hook for consistency and code reuse. [[1]](diffhunk://#diff-3630eb45c636869ef74161877b2b889a54a333eba2e882e0d3de9bac868219d4L2-R5) [[2]](diffhunk://#diff-3630eb45c636869ef74161877b2b889a54a333eba2e882e0d3de9bac868219d4L30-L37) [[3]](diffhunk://#diff-a399d89b65dbce577b0a93feb6b50503760f902ebf1cea516ec3231256be0a5fL1-R6) [[4]](diffhunk://#diff-a399d89b65dbce577b0a93feb6b50503760f902ebf1cea516ec3231256be0a5fL28-L56) [[5]](diffhunk://#diff-9474ca5a3b1b5ca0d1bf5df4184a3260e443bd1cc0b2078257a805036600f509L2-L44) [[6]](diffhunk://#diff-80aeb8e24cffa185026a6049506fd94da330fb1f329f64437410ec46bf5ed860R1-R4) [[7]](diffhunk://#diff-80aeb8e24cffa185026a6049506fd94da330fb1f329f64437410ec46bf5ed860L16-L23)

**Code Organization and Import Cleanup:**

* Separated server-only utilities into `index.server.ts` and client-side utilities into `index.ts`, updating all relevant imports throughout the codebase to use the appropriate entry point. [[1]](diffhunk://#diff-2ee8ad97d8bda446ec54fb1abbe57d5839a9231aa7549eb1c5c835a5455d5918L1-L19) [[2]](diffhunk://#diff-b967ebd9167a196f488cb397ab97d722a942140b48f70e344f90c66dbd94b022R1-R11) [app/[[...slug]]/page.tsxL18-R18](diffhunk://#diff-007d4a2548702159a27c456e316eaa3925ccc99123279aec8c19fe130436d246L18-R18), [[3]](diffhunk://#diff-724dcbd470a504cdf072cab3311f38c43f522c6906d24af1f1bcdd20246ee0c9L6-R8) [[4]](diffhunk://#diff-fe77a89a1d202b09d5414068d5bb054cb4c597e8f5bd1e72f3e05adcaa9b09a4L10-R10) [[5]](diffhunk://#diff-0e87331685ff632f31978e074ca109a215814ca51c6fabef5888b00e7a52a817L3-R3) [app/share/[slug]/page.tsxL4-R4](diffhunk://#diff-28a2e8e5011856b1ffb898b7503b975656e2678c03803ba12d54d1ad457ee6e2L4-R4))
* Updated `getMeta.tsx` to import `getTenant` directly from its file for clarity.

**Feedback Logic Adjustment:**

* Commented out the success feedback dispatch in `initOrders.tsx` to avoid unnecessary user notification when the API health check passes.

These changes improve code maintainability, reduce duplication, and clarify the separation between server and client logic.