### PR TITLE
Prospects: UI updates, Prompt added

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -76,7 +76,7 @@ export default function Prospects({
 
     if (state?.error) {
         return (
-            <Container maxWidth="xs" sx={{ my: 4 }}>
+            <Container maxWidth="md" sx={{ my: 4 }}>
                 <Alert severity="info" sx={{ my: 2 }}>
                     {state.error}
                 </Alert>
@@ -86,14 +86,18 @@ export default function Prospects({
 
     return (
         <>
-            <AppBar position="fixed" sx={{ background: theme.palette.background.default, boxShadow:0, mt: '75px' }}>
+            <AppBar position="fixed" sx={{ 
+                background: theme.palette.background.default, 
+                boxShadow:0, 
+                mt: '75px' 
+            }}>
                 <Toolbar>
                     <Container maxWidth="lg" sx={{ my: 3 }}>
                         <Box sx={{display: 'flex'}}>
                         <Box sx={{ flexGrow: 1, mx: {xs:1, md:4} }}>
                             <Search />
                         </Box>
-                        <Box>
+                        {/* <Box>
                             <Badge badgeContent={basket.length} color='primary'>
                                 <Button
                                     variant="outlined"
@@ -103,7 +107,7 @@ export default function Prospects({
                                     Basket
                                 </Button>
                             </Badge>
-                        </Box>
+                        </Box> */}
                         </Box>
                     </Container>
                 </Toolbar>
@@ -111,7 +115,7 @@ export default function Prospects({
             
             <Container maxWidth="lg" sx={{ my: 4 }}>
                 <Basket />
-                <Grid container spacing={2} sx={{ mt: '60px' }}>
+                <Grid container spacing={2} sx={{ mt: '75px' }}>
                     {Array.isArray(results) && results.length > 0 && results.map((result, idx) => (
                         <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
                             <Result result={result} />

--- a/app/NX/Prospects/actions/resetQuery.tsx
+++ b/app/NX/Prospects/actions/resetQuery.tsx
@@ -7,6 +7,8 @@ export const resetQuery = (): any =>
             const current = getState().redux.prospects;
             const updated = {
                 ...current,
+                pagination: null,
+                results: null,
                 query: null, // or set to a factory default object if needed
             };
             dispatch(setUbereduxKey({ key: 'prospects', value: updated }));

--- a/app/NX/Prospects/components/Prompt.tsx
+++ b/app/NX/Prospects/components/Prompt.tsx
@@ -1,0 +1,45 @@
+"use client";
+import * as React from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Typography,
+    IconButton,
+    Box,
+    useTheme,
+    useMediaQuery
+} from "@mui/material";
+import { useDispatch } from '../../Uberedux';
+import { 
+    useProspects, 
+    updateQuery,
+    setProspects,
+} from '../../Prospects';
+import {Icon} from '../../DesignSystem';
+
+export interface I_Prompt {
+    label?: string;
+}
+
+export default function Prompt({ label }: I_Prompt) {
+
+    const dispatch = useDispatch();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+    React.useEffect(() => {
+        // dispatch(setProspects('basketOpen', true));
+    }, [isMobile]);
+
+    const handleClose = () => {
+        // dispatch(setProspects('basketOpen', false));
+    };
+
+    return (
+        <><Icon icon="ai" /></>
+    );
+}
+

--- a/app/NX/Prospects/components/Result.tsx
+++ b/app/NX/Prospects/components/Result.tsx
@@ -93,85 +93,63 @@ export default function Result({ result }: I_Result) {
             <Dialog fullWidth maxWidth="sm" open={open} onClose={handleClose} fullScreen={isMobile}>
                 <DialogTitle>
                     <CardHeader 
+                        avatar={<Icon icon="company" color="primary" />}
                         sx={{mx:-2}}
-                        action={<Button
-                            startIcon={<Icon icon="left" />}
+                        action={<IconButton
                             onClick={handleClose}
                             color="primary"
                         >
-                            Back
-                        </Button>}
+                            <Icon icon="close" />
+                        </IconButton>}
                         title={result.company_name}
-                        subheader={`${result.first_name} ${result.last_name}`}
+                        subheader={result.title}
                     />
                 </DialogTitle>
                 <DialogContent>
-                    <Grid container spacing={2} alignItems="center">
-                        <Grid size={{ xs: 12, sm: 6 }}>
+                    <Box sx={{ mx: 1 }}>
                             <Typography variant="h6">
-                                {result.title}
+                                {`${result.first_name} ${result.last_name}`}
                             </Typography>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                <Typography
-                                    variant="caption"
-                                    component="a"
-                                    href={`mailto:${result.email}`}
-                                    sx={{ color: 'primary.main', textDecoration: 'underline' }}
-                                >
-                                    {result.email}
-                                </Typography>
-                                <Tooltip title={copied ? 'Copied!' : 'Copy email'} open={Boolean(anchorEl)} disableFocusListener disableHoverListener disableTouchListener>
-                                    <IconButton
-                                        size="small"
-                                        onClick={e => {
-                                            navigator.clipboard.writeText(result.email);
-                                            setCopied(true);
-                                            setAnchorEl(e.currentTarget);
-                                            setTimeout(() => {
-                                                setCopied(false);
-                                                setAnchorEl(null);
-                                            }, 1500);
-                                        }}
-                                        aria-label="Copy email"
-                                    >
-                                        <Icon icon="copy" color="primary" />
-                                    </IconButton>
-                                </Tooltip>
-                            </Box>
-                            
-                        </Grid>
-                        
-                        <Grid size={{ xs: 12, sm: 6 }}>
                             <Typography variant="body1">
                                 {fixPhone(result.corporate_phone)}
                             </Typography>
+                    </Box>
+                    <Box sx={{ mt: 3 }}>
+                        <Button
+                            startIcon={<Icon icon="linkedin" />}
+                            onClick={handleLinkedin}
+                        >
+                            LinkedIn
+                        </Button>
+                        <Button
+                            startIcon={<Icon icon="link" />}
+                            onClick={handleWebsite}
+                        >
+                            Website
+                        </Button>
+                        <br />
+                        <Tooltip title={copied ? 'Copied!' : 'Copy email'} open={Boolean(anchorEl)} disableFocusListener disableHoverListener disableTouchListener>
                             <Button
-                                startIcon={<Icon icon="linkedin" />}
-                                onClick={handleLinkedin}
+                                color="primary"
+                                startIcon={<Icon icon="copy" />}
+                                onClick={e => {
+                                    navigator.clipboard.writeText(result.email);
+                                    setCopied(true);
+                                    setAnchorEl(e.currentTarget);
+                                    setTimeout(() => {
+                                        setCopied(false);
+                                        setAnchorEl(null);
+                                    }, 1500);
+                                }}
+                                aria-label="Copy email"
                             >
-                                LinkedIn
+                                {result.email}
                             </Button>
+                        </Tooltip>
+                        
+                        
 
-                            <Button
-                                startIcon={<Icon icon="link" />}
-                                onClick={handleWebsite}
-                            >
-                                Website
-                            </Button>
-                        </Grid>
-
-                        <Grid size={{ xs: 12 }}>
-                            <Button
-                                fullWidth
-                                variant='contained'
-                                startIcon={<Icon icon="shop" />}
-                                onClick={handleAddToBasket}
-                            >
-                                Add to basket
-                            </Button>
-                        </Grid>
-                    </Grid>
-                    
+                    </Box>
                 </DialogContent>
             </Dialog>
         </>

--- a/app/NX/Prospects/components/Search.tsx
+++ b/app/NX/Prospects/components/Search.tsx
@@ -14,6 +14,7 @@ import {
     updateQuery,
     searchProspects,
     setProspects,
+    resetQuery,
 } from '../../Prospects';
 import {Icon} from '../../DesignSystem';
 
@@ -21,19 +22,20 @@ export interface I_Search {
     label?: string;
 }
 
-export default function Search({ label }: I_Search) {
 
+export default function Search({ label }: I_Search) {
     const dispatch = useDispatch();
     const prospects = useProspects();
     const search = prospects?.query?.search || '';
     const searching = prospects?.searching || null;
     const pagination = prospects?.pagination || null;
 
-        const helperText = pagination
-            ? `Showing page ${pagination.page} of ${pagination.pages} (${pagination.total} results)`
-            : 'Search by name, title, company, email, etc.';
+    const helperText = pagination
+        ? `Showing page ${pagination.page} of ${pagination.pages} (${pagination.total} results)`
+        : 'Search by name, title, company, email, etc.';
 
-
+    // Ref for the input
+    const inputRef = useRef<HTMLInputElement>(null);
 
     // Debounce utility (only for searchProspects)
     const debouncedSearch = useRef<() => void>(null);
@@ -60,18 +62,27 @@ export default function Search({ label }: I_Search) {
         }
     };
 
+    const handleCancel = useCallback(() => {
+        dispatch(resetQuery());
+        // Focus the input after cancelling
+        if (inputRef.current) {
+            inputRef.current.focus();
+        }
+    }, [dispatch]);
+
     return (
         <Box component="form">
             <TextField
                 autoFocus
                 fullWidth
-                variant="standard"
+                variant="filled"
                 helperText={helperText}
                 placeholder={label || 'Search'}
                 inputProps={{ 'aria-label': 'Search' }}
                 value={search}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
+                inputRef={inputRef}
                 InputProps={{
                     startAdornment: (
                         <InputAdornment position="start">
@@ -84,15 +95,27 @@ export default function Search({ label }: I_Search) {
                             </IconButton>
                         </InputAdornment>
                     ),
-                    endAdornment: searching ? (
+                    endAdornment: (
                         <InputAdornment position="end">
-                            <span style={{ display: 'flex', alignItems: 'center' }}>
-                                <span style={{ width: 24, height: 24, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
-                                    <CircularProgress size={20} thickness={5} />
+                            {searching ? (
+                                <span style={{ display: 'flex', alignItems: 'center' }}>
+                                    <span style={{ width: 24, height: 24, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                                        <CircularProgress size={20} thickness={5} />
+                                    </span>
                                 </span>
-                            </span>
+                            ) : search ? (
+                                <IconButton
+                                    color="primary"
+                                    edge="end"
+                                    aria-label="cancel search"
+                                    onClick={handleCancel}
+                                    tabIndex={0}
+                                >
+                                    <Icon icon="cancel" />
+                                </IconButton>
+                            ) : null}
                         </InputAdornment>
-                    ) : null
+                    )
                 }}
             />
             {/* <pre>pagination: {JSON.stringify(pagination, null, 2)}</pre> */}

--- a/app/NX/Prospects/index.tsx
+++ b/app/NX/Prospects/index.tsx
@@ -3,6 +3,7 @@ import Search from './components/Search';
 import Selecta from './components/Selecta';
 import Basket from './components/Basket';
 import Result from './components/Result';
+import Prompt from './components/Prompt';
 import { initProspects } from './actions/initProspects';
 import { addToBasket } from './actions/addToBasket';
 import { updateQuery } from './actions/updateQuery';
@@ -23,6 +24,7 @@ export {
     Selecta,
     Result,
     Basket,
+    Prompt,
     updateQuery,
     resetQuery,
     addToBasket,

--- a/public/free/config.json
+++ b/public/free/config.json
@@ -28,8 +28,8 @@
                     "mode": "dark",
                     "primary": "#ffd849",
                     "secondary": "#ffd849",
-                    "background": "#3775a9",
-                    "paper": "#3775a9",
+                    "background": "#364450",
+                    "paper": "#364450",
                     "text": "#fff"
                 },
                 "light": {


### PR DESCRIPTION
Add a new Prompt component and export it from Prospects. Revamp Result dialog layout: add avatar, replace back button with an icon close action, move contact actions (LinkedIn/Website) and email copy into a consolidated area, simplify content layout and remove the Add to basket button. Update Search to use a filled TextField, add inputRef, show a cancel icon to reset the query (dispatches resetQuery) and keep focus, and refine endAdornment behavior with loading state. Change resetQuery to also clear pagination and results. Minor UI/layout tweaks in Prospects (container size, AppBar formatting, commented out basket badge, increased grid top margin) and update theme background/paper colors in public/free/config.json.