### PR TITLE
Replace ChatResponse with plain paragraph

### DIFF
--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -11,4 +11,4 @@ icon: goldlabel
 
 [ContentCard slug="/techstack"]
 
-[ChatResponse text="In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins."]
+In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins.


### PR DESCRIPTION
Removed the ChatResponse component wrapper in public/free/markdown/index.md and replaced it with a plain paragraph containing the same text to simplify rendering in the markdown file. Also resulted in no trailing newline at EOF.