### PR TITLE
Adjust error handling and feedback in Prospects

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -75,7 +75,7 @@ export default function Prospects({
     if (state?.error) {
         return (
             <Container maxWidth="md" sx={{ my: 4 }}>
-                <Alert severity="info" sx={{ my: 2 }}>
+                <Alert severity="warning" sx={{ my: 2 }}>
                     {state.error}
                 </Alert>
             </Container>

--- a/app/NX/Prospects/actions/initProspects.tsx
+++ b/app/NX/Prospects/actions/initProspects.tsx
@@ -28,7 +28,7 @@ export const initProspects = () =>
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
                 const base = process.env.NEXT_PUBLIC_NX_AI;
-                msg = `Can't reach NX-AI at ${base}`;
+                msg = `Can't reach Python at ${base}`;
             }
             dispatch(setProspects('error', msg));
             dispatch(setProspects('loading', false));

--- a/app/NX/Prospects/actions/searchProspects.tsx
+++ b/app/NX/Prospects/actions/searchProspects.tsx
@@ -25,11 +25,11 @@ export const searchProspects = () => async (
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         dispatch(setUbereduxKey({ key: 'error', value: msg }));
-        dispatch(setFeedback({
-            severity: 'error',
-            title: 'searchProspects Exception',
-            description: msg,
-        }));
+        // dispatch(setFeedback({
+        //     severity: 'error',
+        //     title: 'searchProspects Exception',
+        //     description: msg,
+        // }));
         dispatch(setProspects('searching', false));
     }
 };


### PR DESCRIPTION
Update Prospects UI and error handling:

- Change Alert severity from "info" to "warning" for displayed errors to better reflect urgency.
- Update initProspects unreachable message from "Can't reach NX-AI" to "Can't reach Python" (uses NEXT_PUBLIC_NX_AI env var).
- Comment out the setFeedback dispatch in searchProspects' catch block to silence duplicate/noisy feedback while still setting searching=false.

These tweaks clarify error messaging and reduce noisy UI feedback during failures.