### PR TITLE
Comment fetch, bump version, update markdown content

### DIFF
--- a/app/NX/Shortcodes/components/ContentCard.tsx
+++ b/app/NX/Shortcodes/components/ContentCard.tsx
@@ -26,7 +26,9 @@ export default function ContentCard({
     const markdown = content && content.data ? content.data.data : null;
 
     React.useEffect(() => {
-        dispatch(fetchMarkdown(slug));
+        // TO DO: Implement a robust way to check if the markdown is already loaded before dispatching this action, to avoid unnecessary fetches.
+
+        //dispatch(fetchMarkdown(slug));
     }, [slug, dispatch]);
 
     const handleClick = () => {        

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "scripts": {
     "dev": "yarn kill && yarn install && rm -rf .next && next dev -p 1999 --webpack",
     "build": "next build --webpack",

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -5,10 +5,7 @@ title: NX
 description: New for 2026
 tags: NX, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 icon: goldlabel
+image: /free/png/apps.png
 ---
+[ChatResponse text="In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins."]
 
-[ContentCard slug="/prospects"]
-
-[ContentCard slug="/techstack"]
-
-In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins.


### PR DESCRIPTION
Commented out the automatic fetchMarkdown dispatch in ContentCard.tsx and added a TODO to implement a proper check to avoid unnecessary fetches (prevents repeated network loads until conditional loading is implemented). Bumped package.json version from 2.1.2 to 2.1.3. Updated public/free/markdown/index.md: added an image field, removed ContentCard includes and duplicate raw text, and inserted a ChatResponse shortcode to manage the displayed content. No lock files changed; further work is needed to implement the robust markdown caching/loading behavior.