### PR TITLE
Add useTable hook and show fallback table

### DIFF
--- a/app/NX/Prospects/Prospects.tsx
+++ b/app/NX/Prospects/Prospects.tsx
@@ -19,11 +19,11 @@ import {
     useProspects,
     initProspects,
     Result,
-    Basket,
     updateQuery,
     searchProspects,
     ChipSelect,
     normaliseForChipSelect,
+    useTable,
 } from '../Prospects';
 
 export interface I_Prospects {
@@ -36,6 +36,7 @@ export default function Prospects({
 }: I_Prospects) {
 
     const dispatch = useDispatch();
+    const table = useTable();
     const state = useProspects();
     const theme = useTheme();
     const loading = state?.loading;
@@ -126,16 +127,29 @@ export default function Prospects({
             </AppBar>   
             
             <Container maxWidth="lg" sx={{ my: 2 }}>
-                <Basket />
-                {!results?.length ? null : (
-                    <Grid container spacing={2} sx={{ mt: '125px' }}>
-                        {Array.isArray(results) && results.length > 0 && results.map((result, idx) => (
-                            <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
-                                <Result result={result} autoOpen={idx === 0} />
-                            </Grid>
-                        ))}
-                    </Grid>
-                )}
+                <Box sx={{ mt: '125px' }}>
+                    {Array.isArray(results) && results.length > 0 ? (
+                        <Grid container spacing={2}>
+                            {results.map((result, idx) => (
+                                <Grid key={result.id || idx} size={{ xs: 12, sm: 6 }}>
+                                    <Result result={result} autoOpen={idx === 0} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    ) : Array.isArray(table) && table.length > 0 ? (
+                        <Grid container spacing={2}>
+                            {table.map((row, idx) => (
+                                <Grid key={row.id || idx} size={{ xs: 12, sm: 6 }}>
+                                    <Result result={row} autoOpen={idx === 0} />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    ) : (
+                        <Box sx={{ textAlign: 'center', color: 'text.secondary', py: 8 }}>
+                            No results found.
+                        </Box>
+                    )}
+                </Box>
             </Container>
             {/* <pre>total {JSON.stringify(initialData?.total, null, 2)}</pre> */}
         </>

--- a/app/NX/Prospects/actions/initProspects.tsx
+++ b/app/NX/Prospects/actions/initProspects.tsx
@@ -14,15 +14,16 @@ export const initProspects = () =>
         dispatch(setProspects('loading', true));
         try {
             const base = process.env.NEXT_PUBLIC_NX_AI;
+            // also get the /read endpoint which gives us the first page of data for when no results are present
             const [
                 initial, 
-                // data,
+                table,
             ] = await Promise.all([
                 fetchJson(`${base}prospects/init`),
-                // fetchJson(`${base}prospects/read`)
+                fetchJson(`${base}prospects/read`)
             ]);
             dispatch(setProspects('initialData', initial?.data));
-            // dispatch(setProspects('results', data?.data));
+            dispatch(setProspects('table', table?.data));
             dispatch(setProspects('loading', false));
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);

--- a/app/NX/Prospects/hooks/useTable.tsx
+++ b/app/NX/Prospects/hooks/useTable.tsx
@@ -1,0 +1,6 @@
+import type { T_RootState } from '../../Uberedux/store';
+import { useSelector } from 'react-redux';
+
+export function useTable() {
+    return useSelector((state: T_RootState) => state.redux.prospects?.table);
+}

--- a/app/NX/Prospects/index.tsx
+++ b/app/NX/Prospects/index.tsx
@@ -13,12 +13,12 @@ import { resetQuery } from './actions/resetQuery';
 import { setProspects } from './actions/setProspects';
 import { useInitialData } from './hooks/useInitialData';
 import { useProspects } from './hooks/useProspects';
+import { useTable } from './hooks/useTable';
 import { promptMagentoPlugin } from './lib/prompts';
 import { normaliseForChipSelect } from './lib/normalise';
 import { sendPrompt } from './actions/sendPrompt';
 import { flagProspect } from './actions/flagProspect';
 import { hideProspect } from './actions/hideProspect';
-
 
 export {
     Prospects,
@@ -27,6 +27,7 @@ export {
     setProspects,
     useProspects,
     useInitialData,
+    useTable,
     Search,
     Selecta,
     Result,


### PR DESCRIPTION
Introduce a new useTable hook (redux selector) and export it. Update initProspects to also fetch the /read endpoint and store its data on prospects.table. In Prospects.tsx, wire up useTable and replace the previous Basket/results block with a single container that renders search results, falls back to table rows when no search results exist, or shows a "No results found" message. Also remove the inline Basket component usage and adjust imports accordingly.