### PR TITLE
Add PageLink shortcode and integrate renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
-# Open Source NX 
+## NX 
 
-NX is a modern, full-stack web application framework and platform built on [Next.js](https://nextjs.org/) and [React](https://react.dev/). It provides a robust foundation for building scalable, modular, and high-performance web apps, with a focus on developer experience, design systems, and multi-tenant support.
+Modern, full-stack web application framework and platform built on [Next.js](https://nextjs.org/) and [React](https://react.dev/). It provides a robust foundation for building scalable, modular, and high-performance web apps, with a focus on developer experience, design systems, and multi-tenant support.
 
 In this Open Source release we offer a public repo. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins. 
 
+#### Features
 
-## Quick Start
+- **Next.js 16**: SSR, SSG, API routes, and advanced routing
+- **TypeScript**: Strict typing and modern JavaScript features
+- **Material UI (MUI)**: Beautiful, accessible UI components
+- **Redux Toolkit**: State management
+- **Firebase**: Authentication and backend integration
+- **PWA Support**: Offline-ready with service workers
+- **Multi-Tenant Architecture**: Easily support multiple brands/clients
+- **RESTful API**: Built-in API endpoints ([API Docs](https://goldlabel.pro/api))
+- **Design System**: Reusable components and hooks
+- **Rich Media Support**: Markdown, images, SVG, PDF, and more
+
+#### Quick Start
 
 1. **Clone the repository:**
 	```bash
@@ -23,7 +35,7 @@ In this Open Source release we offer a public repo. Production ready and fully d
 
 The app will be available at [http://localhost:1999](http://localhost:1999). NX exposes a RESTful API under `/api`. See [app/api/README.md](app/api/README.md) for details and [live API docs](https://github.com/goldlabelapps/python-nx-ai).
 
-## Techstack
+#### Techstack
 
 - [Next.js 16](https://nextjs.org/)
 - [React 19](https://react.dev/)
@@ -35,21 +47,7 @@ The app will be available at [http://localhost:1999](http://localhost:1999). NX 
 - [GSAP](https://greensock.com/gsap/)
 - [PWA](https://web.dev/progressive-web-apps/)
 
-## Features
-
-- **Next.js 16**: SSR, SSG, API routes, and advanced routing
-- **TypeScript**: Strict typing and modern JavaScript features
-- **Material UI (MUI)**: Beautiful, accessible UI components
-- **Redux Toolkit**: State management
-- **Firebase**: Authentication and backend integration
-- **PWA Support**: Offline-ready with service workers
-- **Multi-Tenant Architecture**: Easily support multiple brands/clients
-- **RESTful API**: Built-in API endpoints ([API Docs](https://goldlabel.pro/api))
-- **Design System**: Reusable components and hooks
-- **Rich Media Support**: Markdown, images, SVG, PDF, and more
-
-
-## Scripts
+#### Scripts
 
 - `yarn dev` — Start development server
 - `yarn build` — Build for production
@@ -57,17 +55,17 @@ The app will be available at [http://localhost:1999](http://localhost:1999). NX 
 - `yarn lint` — Run ESLint
 - `yarn clean` — Clean build artifacts
 
-## Contributing
+#### Contributing
 
 Contributions are welcome! Please open issues or submit pull requests. 
 For major changes, open an issue first to discuss what you would like to change.
 
-## License
+#### License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
-## Owner
+#### Owner
 
-NX is built and maintained by [Goldlabel Apps Ltd](https://company.goldlabel.pro).
+NX is built and maintained by [Goldlabel Apps Ltd](https://goldlabel.pro).
 
 ![NextJS](public/shared/png/opengraph/apps.png) 

--- a/app/NX/Shortcodes/components/PageLink.tsx
+++ b/app/NX/Shortcodes/components/PageLink.tsx
@@ -1,0 +1,54 @@
+'use client';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Typography,
+  Paper,
+  ButtonBase,
+  CardHeader,
+} from '@mui/material';
+import { Icon, navigateTo } from '../../DesignSystem';
+import { useDispatch } from '../../Uberedux';
+
+export default function PageLink({
+  url = '',
+  icon = 'link',
+  title = 'No title',
+  description = 'No description'
+}: {
+  url?: string;
+  icon?: string;
+  title?: string;
+  description?: string;
+}) {
+
+  const dispatch = useDispatch();
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (url) {
+      dispatch(navigateTo(router, url, '_self'));
+    }
+  };
+
+  return (
+    <ButtonBase 
+      onClick={handleClick}
+      sx={{
+        textAlign: 'left', 
+        width: '100%',
+      }}
+    >
+      <Paper variant="outlined" sx={{ width: '100%' }}>
+        <CardHeader 
+          sx={{
+            width: '100%',
+          }}
+          title={title}
+          subheader={description}
+          avatar={<Icon icon={icon as any} color="primary" />}
+        />
+      </Paper>
+    </ButtonBase>
+  );
+}

--- a/app/NX/Shortcodes/components/RenderMarkdown.tsx
+++ b/app/NX/Shortcodes/components/RenderMarkdown.tsx
@@ -14,6 +14,7 @@ import {
   ChatResponse,
   GithubLink,
   ContentCard,
+  PageLink,
 } from '../../Shortcodes';
 
 export type I_RenderMarkdown = {
@@ -78,6 +79,9 @@ export default function RenderMarkdown({
     const contentCard = parseShortcode(/\[ContentCard\s+(.*?)\]/, ContentCard);
     if (contentCard) return contentCard;
     
+    // PageLink
+    const pageLink = parseShortcode(/\[PageLink\s+(.*?)\]/, PageLink);
+    if (pageLink) return pageLink;
 
     // fallback: simply return text
     return text;

--- a/app/NX/Shortcodes/index.tsx
+++ b/app/NX/Shortcodes/index.tsx
@@ -5,6 +5,7 @@ import FeedbackBtn from "./components/FeedbackBtn";
 import ChatResponse from "./components/ChatResponse";
 import ContentCard from "./components/ContentCard";
 import RenderMarkdown from "./components/RenderMarkdown";
+import PageLink from "./components/PageLink";
 
 export {
     RenderMarkdown,
@@ -13,4 +14,5 @@ export {
     ChatResponse,
     GithubLink,
     ContentCard,
+    PageLink,
 };

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -2,7 +2,7 @@
 order: 1 
 slug: /
 title: NX
-description: JavaScript Whatever the Weather
+description: by Goldlabel
 tags: NX, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 icon: goldlabel
 image: /free/png/apps.png

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -2,12 +2,14 @@
 order: 1 
 slug: /
 title: NX
-description: New for 2026
+description: JavaScript Whatever the Weather
 tags: NX, Multi-tenant, Tenant, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, Server Side JavaScript, Node, NextJS, Headless CMS
 icon: goldlabel
 image: /free/png/apps.png
 ---
-[GithubLink  label="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  
+
+[PageLink icon="prospects" title="Prospects™" description="Be more direct" url="/prospects"]  
 
 [ChatResponse text="In this Open Source release of NX, we offer a public repo for NX. Production ready and fully documented it allows a fullstack JavaScript developer to spin up a fully functinoing Firebase powered NX instance within 30 mins."]
 
+[GithubLink  label="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  


### PR DESCRIPTION
Add a new PageLink shortcode component (app/NX/Shortcodes/components/PageLink.tsx) that renders clickable page cards and dispatches navigate actions. Integrate PageLink into shortcodes exports and the markdown renderer so [PageLink ...] tags are parsed. Update example markdown to include a PageLink entry and make minor README content/formatting adjustments.