### PR TITLE
Update factoryReset call and remove Prospects link

### DIFF
--- a/app/NX/Prospects/components/HammerMenu.tsx
+++ b/app/NX/Prospects/components/HammerMenu.tsx
@@ -53,8 +53,7 @@ export default function HammerMenu() {
 
     const handleDialogConfirm = () => {
         if (dialogAction === 'factoryReset') {
-            // You may want to pass a real id and flag value here
-            dispatch(factoryReset(0, true, 'Factory Reset complete'));
+            dispatch(factoryReset('Factory Reset complete'));
         }
         setDialogOpen(false);
         setDialogAction(null);

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -14,6 +14,4 @@ icon: mobile
 
 [PageLink icon="techstack" title="Techstack" url="/techstack" description="Modern, full-stack web application framework and platform built on Next.js and Reacts"]  
 
-[PageLink icon="prospects" title="Prospects°" url="/prospects" description="Be more direct"]  
-
 [PageLink icon="virus" title="魏魏°" description="我不是来和蜘蛛交配的" url="/tenants/nhtfs"]  


### PR DESCRIPTION
Adjust HammerMenu to call factoryReset with the updated single-argument signature (pass only the completion message) and remove an outdated inline comment. Also remove the Prospects PageLink from public/free/markdown/index.md to clean up the homepage links.