### PR TITLE
Update free docs and add tenant pages

### DIFF
--- a/public/free/README.md
+++ b/public/free/README.md
@@ -21,3 +21,7 @@ CREATE TABLE prospects (
     name TEXT
 );
 ```
+
+monkey
+image: https://live.staticflickr.com/65535/55196635250_f69fd14b3f_c.jpg
+

--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -7,11 +7,11 @@ tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaSc
 image: /free/png/python.png
 icon: mobile
 ---
+[PageLink icon="mobile" title="Tenants°" description="Separate apps. Same NextJS codebase"  url="/tenants"]   
 
-[PageLink icon="github" title="Open Source" description="NX° is production ready and fully documented, letting a fullstack JavaScript developer launch a working Firebase-powered NX instance in under an hour" url="/techstack/git"]  
+[PageLink icon="github" title="Open Source" description="Free, open source NextJS app framework for rapid fullstack development" url="/techstack/git"]  
 
-[PageLink icon="mobile" title="Tenants°" description="Separate groups or customers, each with their own data and settings, sharing the same Next.js app."  url="/tenants"]   
 
-[PageLink icon="techstack" title="Techstack" url="/techstack" description="Modern, full-stack web application framework and platform built on Next.js and Reacts"]  
+[PageLink icon="techstack" title="Techstack" url="/techstack" description="Built Next.js React & Python"]  
 
 [PageLink icon="virus" title="魏魏°" description="我不是来和蜘蛛交配的" url="/tenants/nhtfs"]  

--- a/public/free/markdown/pricing.md
+++ b/public/free/markdown/pricing.md
@@ -5,17 +5,16 @@ description: Start free and scale up as needed
 slug: /pricing
 tags: javascript, nextjs, frontend, backend, resend
 icon: cash
-image: https://live.staticflickr.com/65535/55196635250_f69fd14b3f_c.jpg
 ---
 > [CleverText text="SaaS ensures a hassle free experience with access to the latest improvements"]
 
-#### NX as a Service (SaaS)
+### NX as a Service (SaaS)
 
 For clients who prefer a fully managed experience, we offer NX as a Service. We handle setup, hosting, updates, and ongoing management. Clients receive their own dedicated tenant on a custom domain, with essential apps like Orders° and the EchoPay OpenBank plugin included. 
 
 Pricing starts at **£500/month**, with the final cost depending on selected features. 
 
-#### Free & Open Source
+### Free & Open Source
 
 The core NX platform is free and open source on [GitHub](https://github.com/goldlabelapps/nx). Anyone can deploy their own independent tenant, similar to how WordPress operates. This option is ideal for those who want full control and are comfortable with self-hosting.
 
@@ -23,6 +22,6 @@ The core NX platform is free and open source on [GitHub](https://github.com/gold
 - Community support via GitHub  
 - Guaranteed to remain free and open source
 
-#### Setup & Configured
+### Setup & Configured
 
 For a one-time flat fee of **£1000**, we set up and configure NX for you, resolve any initial issues, and hand over the instance after two weeks. Ongoing management is not included, but you retain full control

--- a/public/free/markdown/techstack/git.md
+++ b/public/free/markdown/techstack/git.md
@@ -7,7 +7,7 @@ icon: blokey
 tags: open source, free, git, github
 --- 
 
-[PageLink icon="github" description="Our open source NX repo is production-ready and fully documented, letting any fullstack JavaScript developer launch a working Firebase-powered NX instance in under 30 minutes." title="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  
+[PageLink icon="github" description="Free, open source NextJS app framework for rapid fullstack development" title="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  
 
 [PageLink icon="github" description="Open Source, production ready Python FastAPI/Postgres app for NX" title="goldlabelapps/python" url="https://github.com/goldlabelapps/python"]  
 

--- a/public/free/markdown/techstack/nextjs.md
+++ b/public/free/markdown/techstack/nextjs.md
@@ -1,11 +1,13 @@
 ---
 order: 472
 title: Next.js
-description: TypeScript with Node and React
+description: Fullstack Node and React
 slug: /techstack/nextjs
 tags: javascript, nextjs, frontend, backend
 icon: js
 ---
+
+[PageLink icon="github" description="Our open source NX repo is production-ready and fully documented, letting any fullstack JavaScript developer launch a working Firebase-powered NX instance in under 30 minutes." title="goldlabelapps/nx" url="https://github.com/goldlabelapps/nx"]  
 
 > [CleverText text="The world’s most popular environment for developing fast, scalable, and production-ready web applications"]
 

--- a/public/free/markdown/techstack/tsvector.md
+++ b/public/free/markdown/techstack/tsvector.md
@@ -2,14 +2,18 @@
 order: 495
 slug: /techstack/tsvector
 title: tsvector
-description: Data types designed to support full text search
+description: Superfast full text search
 tags: Python, FastAPI, tsvector, Postgres, PostgreSQL, data types,
 icon: api
 ---
 
-
-PostgreSQL provides two data types that are designed to support full text search, which is the activity of searching through a collection of natural-language documents to locate those that best match a query. The tsvector type represents a document in a form optimized for text search; the tsquery type similarly represents a text query.
+[PageLink icon="github" description="Open Source, production ready Python FastAPI/Postgres app for NX" title="goldlabelapps/python" url="https://github.com/goldlabelapps/python"]  
 
 > [CleverText text="Superfast search with tsvector"]  
 
+PostgreSQL provides two data types that are designed to support full text search, which is the activity of searching through a collection of natural-language documents to locate those that best match a query. The tsvector type represents a document in a form optimized for text search; the tsquery type similarly represents a text query.
+
+
+
 What makes tsvector brilliant is its ability to turn messy, unstructured text into a lightning-fast, searchable format right inside your database. With tsvector, you get powerful, language-aware search capabilities—ranking, stemming, and relevance without leaving Postgres. It’s great for building search features that feel instant and smart.
+

--- a/public/free/markdown/techstack/typescript.md
+++ b/public/free/markdown/techstack/typescript.md
@@ -6,12 +6,11 @@ slug: /techstack/typescript
 icon: js
 tags: Techstack, javascript, typescript
 ---
-
-> [CleverText text="JavaScript whatever the weather "]  
-
-TypeScript is a powerful, statically typed superset of JavaScript that brings type safety, better tooling, and improved developer productivity to modern web development. It helps catch errors early, makes code easier to maintain, and enables you to build large, robust applications with confidence.
-
 [PageLink icon="js" title="NextJS" url="/techstack/nextjs"] 
 
 [PageLink icon="js" title="React" url="/techstack/react"]  
+    
+> [CleverText text="JavaScript whatever the weather "]  
+
+TypeScript is a powerful, statically typed superset of JavaScript that brings type safety, better tooling, and improved developer productivity to modern web development. It helps catch errors early, makes code easier to maintain, and enables you to build large, robust applications with confidence.
 

--- a/public/free/markdown/tenants/index.md
+++ b/public/free/markdown/tenants/index.md
@@ -1,14 +1,16 @@
 ---
-order: 100
+order: 500
 title: Tenants°
-description: Separate apps. Same Next.js codebase
+description: Separate apps. Same NextJS codebase
 slug: /tenants
 icon: mobile
 tags: tenants, apps,
 ---
 
-Tenants are separate groups or customers, each with their own data and settings, sharing the same Next.js app.
-
 [PageLink icon="rocket" title="Edtech°" description="Educational Technology" url="/tenants/edtech"]  
 
 [PageLink icon="virus" title="魏魏°" description="我不是来和蜘蛛交配的" url="/tenants/nhtfs"]  
+
+[PageLink icon="orders" title="Orders°" description="Sell more" url="/tenants/orders"]  
+
+[PageLink icon="prospects" title="Prospects°" description="Be more direct" url="/tenants/prospects"]  

--- a/public/free/markdown/tenants/orders.md
+++ b/public/free/markdown/tenants/orders.md
@@ -1,0 +1,9 @@
+---
+order: 765
+title: Orders°
+description: Educational Technology
+slug: /tenants/orders
+icon: orders
+tags: orders
+cartridge: orders
+---

--- a/public/free/markdown/tenants/prospects.md
+++ b/public/free/markdown/tenants/prospects.md
@@ -1,0 +1,9 @@
+---
+order: 769
+title: prospects°
+description: Be more direct
+slug: /tenants/prospects
+icon: prospects
+tags: prospects
+cartridge: prospects
+---


### PR DESCRIPTION
Editorial and structural updates to public/free docs: revise page descriptions and PageLink content across index, techstack (Next.js, git, tsvector, typescript) and pricing pages; add an image/note and minor formatting fixes in README; bump tenants index order, normalize Tenants description, add links for Orders° and Prospects°; add new tenant pages tenants/orders.md and tenants/prospects.md. These changes improve copy, navigation, and introduce two new tenant cartridges.