### PR TITLE
Orders: init, search and UI enhancements

### DIFF
--- a/app/NX/Orders/Orders.tsx
+++ b/app/NX/Orders/Orders.tsx
@@ -4,27 +4,95 @@ import { useRouter } from 'next/navigation';
 import { 
   Box, 
   Alert,
+  Button,
+  Container,
+  Typography,
 } from '@mui/material';
 import { init, useState } from '../../NX/Orders';
 import { useDispatch } from '../../NX/Uberedux';
+import {
+  Icon,
+} from '../DesignSystem';
 
 export default function Orders() {
 
+  const dispatch = useDispatch(); 
   const state = useState();
-  const dispatch = useDispatch();
+  const {
+    error,
+    initted,
+    pagination,
+    search,
+    results,
+  } = state || {};
 
   React.useEffect(() => {
-      if (!state) {
+    if (!initted) {
           dispatch(init());
       }
-  }, [state, dispatch]);
+  }, [initted, dispatch]);
 
+  if (!initted) return null
+
+  if (error) {
+    return (
+      <Container maxWidth="lg" sx={{ my: 4 }}>
+        <Alert severity="info" sx={{ my: 2 }}
+          action={
+            <Button
+              startIcon={<Icon icon="reset" />}
+              variant="contained"
+              color="primary"
+              onClick={() => window.location.reload()}
+            >
+              Retry
+            </Button>
+          }
+        >
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+  
   return (<>
       <Box>
-        <Alert severity="warning">
-          Orders
-        </Alert>
-        <pre>state: {JSON.stringify(state, null, 2)}</pre>
+        {pagination && (
+          <Typography variant="subtitle1" sx={{ mb: 2 }} align="center">
+            {(() => {
+              const { page, limit, total } = pagination;
+              if (!page || !limit || !total) return null;
+              const start = (page - 1) * limit + 1;
+              const end = Math.min(page * limit, total);
+              return `Showing ${start}-${end} of ${total} results`;
+            })()}
+          </Typography>
+        )}
+
+        {search && search.searchStr && (
+          <Typography variant="subtitle2" align="center" sx={{ mb: 2 }}>
+            {search.searchStr}
+          </Typography>
+        )}
+
+        {results && results.length === 0 && (
+          <Typography variant="body1" align="center" sx={{ mb: 2 }}>
+            No results found.
+          </Typography>
+        )}
+
+        {results && results.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            {results.map((order: any, idx: number) => (
+              <Box key={order.id ?? idx} sx={{}}>
+                <Typography variant="body1">
+                  {order.name}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+        
       </Box>
     </>
   );

--- a/app/NX/Orders/actions/init.tsx
+++ b/app/NX/Orders/actions/init.tsx
@@ -18,23 +18,40 @@ async function fetchJson(endpoint: string) {
 export const init = () =>
     async (dispatch: T_UbereduxDispatch) => {
         try {
-            dispatch(setKey('loadingOrders', true));
+            dispatch(setKey('loading', true));
+            // set default search params from search.tsx
+            // import { defaultOrderSearchParams } from './search';
+            // (import at top required)
+            const { defaultOrderSearchParams } = await import('./search');
+            dispatch(setKey('searchParams', defaultOrderSearchParams));
+
+            // check the api health
             const base = process.env.NEXT_PUBLIC_PYTHON_URL;
-            const [
-                health,
-            ] = await Promise.all([
+            const [health] = await Promise.all([
                 fetchJson(`${base}health`),
             ]);
             dispatch(setKey('health', health));
-            dispatch(setKey('loadingOrders', false));
+            if (health && health.status === 'ok') {
+                // Only dispatch search if health is ok
+                const { search } = await import('./search');
+                dispatch(search());
+                dispatch(setKey('loading', false));
+            } else {
+                const msg = 'Health check failed: status not ok';
+                dispatch(setKey('error', msg));
+                dispatch(setUbereduxKey({ key: 'error', value: msg }));
+                dispatch(setKey('loading', false));
+            }
+            dispatch(setKey('initted', true));
         } catch (e) {
             let msg = e instanceof Error ? e.message : String(e);
             if (msg === 'Failed to fetch') {
                 const base = process.env.NEXT_PUBLIC_PYTHON_URL;
-                msg = `Can't reach Python at ${base}/health`;
+                msg = `Python endpoint unhealthy ${base}health`;
             }
             dispatch(setKey('error', msg));
-            dispatch(setKey('loadingOrders', false));
+            dispatch(setKey('loading', false));
+            dispatch(setKey('initted', true));
             dispatch(setUbereduxKey({ key: 'error', value: msg }));
         }
     };

--- a/app/NX/Orders/actions/search.tsx
+++ b/app/NX/Orders/actions/search.tsx
@@ -1,3 +1,10 @@
+// Default search params for orders
+export const defaultOrderSearchParams = {
+    s: '', // search string
+    page: 1,
+    limit: 25,
+    // hideflagged: false, // add if needed
+};
 import type { T_UbereduxDispatch, T_RootState } from '../../types';
 import { setUbereduxKey } from '../../Uberedux';
 import { setFeedback } from '../../DesignSystem';
@@ -9,21 +16,27 @@ export const search = () => async (
 ) => {
     try {
         dispatch(setKey('loading', true));
-        const state = getState().redux.prospects;
-        const page = state?.query?.page || 1;
-        const limit = state?.query?.limit || 100;
-        // const searchStr = state?.searchStr || '';
-        const searchStr = 'Rival Field';
-        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}orders?s=${encodeURIComponent(searchStr)}&page=${page}&limit=${limit}`;
+        const state = getState().redux.orders;
+        const params = state?.searchParams || defaultOrderSearchParams;
+        const query = new URLSearchParams({
+            s: params.s || '',
+            page: String(params.page || 1),
+            limit: String(params.limit || 10),
+            // ...(params.hideflagged !== undefined ? { hideflagged: String(params.hideflagged) } : {})
+        }).toString();
+        const endpoint = `${process.env.NEXT_PUBLIC_PYTHON_URL}orders?${query}`;
         const res = await fetch(endpoint);
         if (!res.ok) throw new Error(`Failed to fetch: ${endpoint}`);
         const data = await res.json();
         if (data?.data) {
             dispatch(setKey('results', data.data));
             dispatch(setKey('pagination', data.pagination));
+            dispatch(setKey('search', data.search));
         } else {
             dispatch(setKey('results', []));
             dispatch(setKey('pagination', null));
+            dispatch(setKey('search', null));
+            
         }
         dispatch(setKey('loading', false));
     } catch (e: unknown) {


### PR DESCRIPTION
Refactor Orders UI and actions: add a cleaner Orders component that waits for init, shows pagination summary, current search string, results list or "No results" message, and an error Alert with a Retry button. Introduce defaultOrderSearchParams and update search to build a URLSearchParams query from state.searchParams (use orders slice). Update init to set default search params, run a health check before dispatching search, set initted/loading flags, and improve error messages. Misc: rename loadingOrders -> loading and persist search/pagination/results/search state from API.