### PR TITLE
Remove AIExample snippet from markdown index

### DIFF
--- a/public/free/markdown/index.md
+++ b/public/free/markdown/index.md
@@ -7,8 +7,6 @@ tags: NX, framework, fullstack, Multi-tenant, Tenant, JavaScript, Vanilla JavaSc
 icon: mobile
 ---
 
-[AIExample title="Try our AI"]  
-
 [PageLink icon="mobile" title="Tenants°" description="Separate apps. Same NextJS codebase"  url="/tenants"]   
 
 [PageLink icon="github" title="Open Source" description="Free, open source NextJS app framework for rapid fullstack development" url="/techstack/git"]  


### PR DESCRIPTION
Remove the AIExample shortcode ("Try our AI") and an extra blank line from public/free/markdown/index.md to clean up the page content and leave only the PageLink entries.