### PR TITLE
Remove unused flash prop and old cartridges

### DIFF
--- a/app/NX/NX.tsx
+++ b/app/NX/NX.tsx
@@ -9,7 +9,6 @@ import { setDesignSystem, useDesignSystem } from './DesignSystem';
 const NX: React.FC<I_NX> = ({
     children,
     config,
-    flash,
 }) => {
     const dispatch = useDispatch();
     const designSystem = useDesignSystem();
@@ -42,11 +41,6 @@ const NX: React.FC<I_NX> = ({
                 {children}
             </Box>
         );
-    }
-
-    let flashContent = children;
-    if (flash === 'EchoPay') {
-        //flashContent = <EchoPay />;
     }
 
     return (

--- a/app/NX/types.d.ts
+++ b/app/NX/types.d.ts
@@ -49,24 +49,6 @@ export type T_Config = {
         dark: string;
     };
     cartridges: {
-        nxadmin?: {
-            enabled: boolean;
-            layout?: string;
-        },
-        orders?: {
-            enabled: boolean;
-            frontPage: string;
-            adminPage: string;
-        },
-        async?: {
-            enabled: boolean;
-        },
-        tings?: {
-            enabled: boolean;
-        },
-        paywall?: {
-            enabled: boolean;
-        },
         designSystem?: {
             themeSwitching: boolean;
             defaultTheme: string;


### PR DESCRIPTION
Remove the unused `flash` prop and related flash-handling code from the NX React component, cleaning up dead/commented logic. Also remove several obsolete cartridge type definitions (nxadmin, orders, async, tings, paywall) from T_Config to simplify the config types. These changes are a types/code cleanup to reduce unused surface area and keep the component and config types focused.