### PR TITLE
Add NX° Turbo header to docs guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,16 @@
+<div>
+	<h1 style="display: flex; align-items: center; gap: 8px;">
+		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+		<img
+			src="./media/nx-icon.png"
+			width="24"
+			height="24"
+		/>
+		</a>
+		<span>NX° Turbo</span>
+	</h1>
+</div>
+
 # Documentation Home
 
 This folder is the canonical location for repository documentation.

--- a/docs/api-typescript.md
+++ b/docs/api-typescript.md
@@ -1,3 +1,16 @@
+<div>
+	<h1 style="display: flex; align-items: center; gap: 8px;">
+		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+		<img
+			src="./media/nx-icon.png"
+			width="24"
+			height="24"
+		/>
+		</a>
+		<span>NX° Turbo</span>
+	</h1>
+</div>
+
 # API + TypeScript Guide
 
 ## API Location

--- a/docs/leida.md
+++ b/docs/leida.md
@@ -1,3 +1,16 @@
+<div>
+	<h1 style="display: flex; align-items: center; gap: 8px;">
+		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+		<img
+			src="./media/nx-icon.png"
+			width="24"
+			height="24"
+		/>
+		</a>
+		<span>NX° Turbo</span>
+	</h1>
+</div>
+
 # Leida Guide
 
 ## Purpose

--- a/docs/nx.md
+++ b/docs/nx.md
@@ -1,3 +1,16 @@
+<div>
+	<h1 style="display: flex; align-items: center; gap: 8px;">
+		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+		<img
+			src="./media/nx-icon.png"
+			width="24"
+			height="24"
+		/>
+		</a>
+		<span>NX° Turbo</span>
+	</h1>
+</div>
+
 # NX Guide
 
 ## Purpose

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,3 +1,16 @@
+<div>
+	<h1 style="display: flex; align-items: center; gap: 8px;">
+		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+		<img
+			src="./media/nx-icon.png"
+			width="24"
+			height="24"
+		/>
+		</a>
+		<span>NX° Turbo</span>
+	</h1>
+</div>
+
 # Testing Guide
 
 ## Stack

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,3 +1,16 @@
+<div>
+	<h1 style="display: flex; align-items: center; gap: 8px;">
+		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+		<img
+			src="./media/nx-icon.png"
+			width="24"
+			height="24"
+		/>
+		</a>
+		<span>NX° Turbo</span>
+	</h1>
+</div>
+
 # Theme module
 
 This module owns presentation integration for the Leida app, including the app's MUI theme adapter and the shared monorepo design-system wiring.


### PR DESCRIPTION
Prepends a shared branded header block to key docs pages (README, API+TypeScript, Leida, NX, Testing, and Theme). This standardizes documentation presentation with the NX icon + title and a consistent link back to the repo root.