### PR TITLE
Fix docs header link to root README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <div>
 	<h1 style="display: flex; align-items: center; gap: 8px;">
-		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+				<a href="../README.md" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
 		<img
 			src="./media/nx-icon.png"
 			width="24"

--- a/docs/api-typescript.md
+++ b/docs/api-typescript.md
@@ -1,6 +1,6 @@
 <div>
 	<h1 style="display: flex; align-items: center; gap: 8px;">
-		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+				<a href="../README.md" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
 		<img
 			src="./media/nx-icon.png"
 			width="24"

--- a/docs/leida.md
+++ b/docs/leida.md
@@ -1,6 +1,6 @@
 <div>
 	<h1 style="display: flex; align-items: center; gap: 8px;">
-		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+				<a href="../README.md" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
 		<img
 			src="./media/nx-icon.png"
 			width="24"

--- a/docs/nx.md
+++ b/docs/nx.md
@@ -1,6 +1,6 @@
 <div>
 	<h1 style="display: flex; align-items: center; gap: 8px;">
-		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+				<a href="../README.md" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
 		<img
 			src="./media/nx-icon.png"
 			width="24"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 <div>
 	<h1 style="display: flex; align-items: center; gap: 8px;">
-		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+				<a href="../README.md" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
 		<img
 			src="./media/nx-icon.png"
 			width="24"

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,6 +1,6 @@
 <div>
 	<h1 style="display: flex; align-items: center; gap: 8px;">
-		<a href="../" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+				<a href="../README.md" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
 		<img
 			src="./media/nx-icon.png"
 			width="24"


### PR DESCRIPTION
Updated the top navigation link in multiple docs pages to point explicitly to `../README.md` instead of `../`, ensuring consistent behavior when opening documentation files directly.