### PR TITLE
Rename app package and bump version

### DIFF
--- a/apps/free.goldlabel.pro/package.json
+++ b/apps/free.goldlabel.pro/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nx",
-  "version": "3.0.1",
+  "name": "free",
+  "version": "3.0.2",
   "scripts": {
     "dev": "pnpm run kill && rm -rf .next && next dev -p 1999 --webpack",
     "build": "next build --webpack",


### PR DESCRIPTION
Updates `apps/free.goldlabel.pro/package.json` to use the package name `free` instead of `nx`, and bumps the app version from `3.0.1` to `3.0.2` for the next release.