### PR TITLE
Add design-system concept lab prompt toolkit

### DIFF
--- a/.github/prompts/design-system-generate-concepts.prompt.md
+++ b/.github/prompts/design-system-generate-concepts.prompt.md
@@ -1,0 +1,34 @@
+---
+name: "Design System: Generate Concepts"
+description: "Generate 3 design-system-aligned UI concepts for a page, flow, or component in this repo"
+argument-hint: "Describe the page, flow, or component to explore"
+agent: "agent"
+---
+
+Generate 3 clearly different design concepts for the user's requested page, flow, or component.
+
+Use these repo references as hard constraints:
+- [Design system overview](../../docs/features/design-system.md)
+- [Copilot prompt pack](../../docs/features/design-system-copilot-prompts.md)
+- [Token decision](../../docs/decisions/002-design-tokens.md)
+- [Brand rules and component guidance](../../packages/design-system/SKILL.md)
+
+Requirements:
+- Reuse the existing design system and tokens.
+- Prefer existing primitives before inventing anything new.
+- Do not hardcode visual values that should come from tokens.
+- Keep the concepts realistic for the current codebase.
+- Make the concepts meaningfully different in hierarchy, density, and tone.
+
+For each concept, return:
+- Name
+- Intent
+- Visual idea in 3 to 5 sentences
+- Existing primitives to reuse
+- New patterns or variants proposed
+- Token usage notes
+- Accessibility notes
+- Main risk
+- Recommendation on whether the new parts should stay local or become shared
+
+If the brief is too vague, ask only the minimum follow-up questions needed to generate useful concepts.

--- a/.github/prompts/design-system-review-concept.prompt.md
+++ b/.github/prompts/design-system-review-concept.prompt.md
@@ -1,0 +1,38 @@
+---
+name: "Design System: Review Concept"
+description: "Critically review a UI concept against this repo's design-system, token, and accessibility rules"
+argument-hint: "Paste or describe the concept to review"
+agent: "agent"
+---
+
+Review the user's concept as a design-system critic.
+
+Use these repo references:
+- [Review checklist](../../docs/features/design-system-review-checklist.md)
+- [Copilot prompt pack](../../docs/features/design-system-copilot-prompts.md)
+- [Design system overview](../../docs/features/design-system.md)
+- [Brand rules and component guidance](../../packages/design-system/SKILL.md)
+
+Evaluate the concept against:
+- Brand fit
+- Token discipline
+- Reuse of existing primitives
+- Accessibility
+- Responsive behavior
+- Content clarity
+- Implementation complexity
+- Risk of one-off patterns
+
+Return findings first, ordered by severity.
+
+For each finding:
+- Title
+- Why it matters
+- The smallest change that would fix or reduce it
+
+Then end with:
+- What is strong
+- What must change before prototyping
+- Whether the concept should be approved, revised, kept local, or rejected
+
+If there are no significant findings, say that explicitly and mention any residual risk or testing gap.

--- a/.github/prompts/design-system-systemize-patterns.prompt.md
+++ b/.github/prompts/design-system-systemize-patterns.prompt.md
@@ -1,0 +1,31 @@
+---
+name: "Design System: Systemize Pattern"
+description: "Classify approved UI ideas into tokens, primitives, variants, composed patterns, or local-only code"
+argument-hint: "Describe the approved concept or pattern"
+agent: "agent"
+---
+
+Given the user's approved concept or pattern, decide what should enter the shared design system.
+
+Use these repo references:
+- [Copilot prompt pack](../../docs/features/design-system-copilot-prompts.md)
+- [Review checklist](../../docs/features/design-system-review-checklist.md)
+- [Token decision](../../docs/decisions/002-design-tokens.md)
+- [Brand rules and component guidance](../../packages/design-system/SKILL.md)
+
+Classify each proposed addition as one of:
+- Token
+- Primitive
+- Component variant
+- Composed pattern
+- Local-only implementation
+
+For each item, return:
+- Classification
+- Why it belongs there
+- Which existing primitives it depends on
+- Whether it needs a new API surface
+- Whether it needs documentation with examples and dos or don'ts
+- Main risk if it is promoted too early
+
+End with a short recommendation on the minimum system changes needed to support the concept cleanly.

--- a/docs/features/design-system-copilot-prompts.md
+++ b/docs/features/design-system-copilot-prompts.md
@@ -1,0 +1,216 @@
+# Design System Copilot Prompt Pack
+
+Use these prompts to generate and review design ideas without drifting away from the shared design system.
+
+Pair this prompt pack with the review gate in [docs/features/design-system-review-checklist.md](./design-system-review-checklist.md).
+
+## How to use this pack
+
+- Start with a narrow brief: one page, flow, or component at a time.
+- Name the design constraints up front: tokens, typography, spacing, interaction rules, accessibility, and brand voice.
+- Ask for multiple distinct directions, then force tradeoff analysis.
+- Do not promote a pattern into the shared system until it survives review and appears reusable.
+
+## Shared context block
+
+Paste this block before any of the prompts below and adjust as needed.
+
+```md
+You are designing inside an existing design system.
+
+Constraints:
+- Use the existing design tokens as the source of truth for color, spacing, type, radius, shadow, and motion.
+- Prefer existing shared primitives before inventing a new component.
+- Do not hardcode visual values that should come from tokens.
+- Keep the result accessible: clear hierarchy, keyboard-safe interactions, responsive layout, and strong contrast.
+- Treat the output as a system proposal, not a one-off mock.
+
+Brand and UI rules:
+- Use the current product voice and visual rules from the design-system docs.
+- Reuse established patterns for buttons, cards, navigation, and feedback.
+- When proposing something new, explain whether it should become a token, primitive, composed component, or remain local.
+
+Output format:
+- Intent
+- Layout summary
+- Component list
+- Token usage notes
+- Accessibility notes
+- Risks
+- Recommendation
+```
+
+## Prompt 1: Generate design directions
+
+```md
+Generate 3 clearly different design concepts for [page, flow, or component].
+
+Goal:
+[describe the user job and success condition]
+
+Audience:
+[describe the user and context]
+
+Constraints:
+- Reuse the existing design system and tokens.
+- Keep implementation realistic for the current codebase.
+- Avoid one-off styling unless you justify it.
+
+For each concept:
+- Name the concept.
+- Describe the visual idea in 3 to 5 sentences.
+- List which existing primitives should be reused.
+- List what is new.
+- Call out what should become shared if this direction is chosen.
+- Identify one main risk.
+
+Make the 3 concepts meaningfully different in hierarchy, density, and tone.
+```
+
+## Prompt 2: Explore one concept more deeply
+
+```md
+Take concept [name] and turn it into a more concrete design spec.
+
+Include:
+- Section-by-section layout breakdown
+- Desktop and mobile behavior
+- Interaction states
+- Content hierarchy
+- Token categories that drive the design
+- Existing components to reuse
+- New primitives or variants that would be required
+
+Flag anything that looks visually strong but systemically weak.
+```
+
+## Prompt 3: Review a concept critically
+
+```md
+Review this design concept as a design-system critic.
+
+Evaluate it against these criteria:
+- Brand fit
+- Token compliance
+- Reuse of existing primitives
+- Accessibility
+- Responsive behavior
+- Content clarity
+- Implementation complexity
+- Risk of creating one-off patterns
+
+For each criterion:
+- Give a short verdict: strong, acceptable, weak
+- Explain why
+- Suggest the smallest improvement that would raise the score
+
+End with:
+- What should be rejected
+- What should be revised
+- What is ready to prototype
+```
+
+## Prompt 4: Compare competing ideas
+
+```md
+Compare these two or three design concepts for [page, flow, or component].
+
+Judge them on:
+- Clarity of user journey
+- Consistency with the current design system
+- Opportunity for reuse across the product
+- Accessibility risk
+- Engineering cost
+- Likelihood of aging well
+
+Return:
+- A winner
+- A runner-up
+- Which elements from the losing concepts should still be kept
+- A merged recommendation if the best solution is hybrid
+```
+
+## Prompt 5: Decide what becomes systemized
+
+```md
+Given this approved concept, identify what should enter the design system.
+
+Classify each proposed addition as one of:
+- Token
+- Primitive
+- Component variant
+- Composed pattern
+- Local-only implementation
+
+For each item:
+- Explain why it belongs in that category
+- Name dependencies on existing primitives
+- Identify any naming or API concerns
+- State whether it should be documented with examples and dos or don'ts
+```
+
+## Prompt 6: Turn a concept into build-ready UI guidance
+
+```md
+Convert this design concept into implementation-ready guidance for a frontend engineer.
+
+Return:
+- The component tree
+- Required states
+- Responsive rules
+- Content constraints
+- Token categories to use
+- Accessibility requirements
+- What should not be custom styled
+
+Do not generate code yet. Produce a structured handoff that preserves the system.
+```
+
+## Prompt 7: Run a pre-build red-team pass
+
+```md
+Red-team this UI proposal before implementation.
+
+Look for:
+- Hidden one-off styling
+- Token drift
+- Duplicate patterns that should reuse an existing primitive
+- Weak empty, loading, error, or disabled states
+- Mobile layout failures
+- Accessibility regressions
+- Brand inconsistencies
+
+Return only concrete findings, ordered by severity, with a recommended fix for each.
+```
+
+## Review rubric
+
+Use this simple scorecard when narrowing ideas.
+
+| Criterion | 1 | 3 | 5 |
+| --- | --- | --- | --- |
+| Brand fit | Generic or off-brand | Mostly aligned | Distinctly aligned |
+| Token discipline | Frequent drift | Minor exceptions | Clean token usage |
+| Reuse potential | Mostly one-off | Some reusable parts | Naturally systemized |
+| Accessibility | Major gaps | Acceptable with fixes | Strong by default |
+| Buildability | Costly or vague | Moderate effort | Clear and efficient |
+
+Reject concepts that score high visually but low on token discipline or reuse potential.
+
+## Recommended working loop
+
+1. Use Prompt 1 to generate options.
+2. Use Prompt 4 to narrow to one direction.
+3. Use Prompt 2 to deepen the winner.
+4. Use Prompt 3 and Prompt 7 to critique it.
+5. Use Prompt 5 to decide what enters the design system.
+6. Use Prompt 6 to hand the result to implementation.
+
+Prototype disposable concepts in [packages/design-system/templates/concept-lab/ConceptLab.dc.html](../../packages/design-system/templates/concept-lab/ConceptLab.dc.html) before moving anything into app code. Usage notes live in [packages/design-system/templates/concept-lab/README.md](../../packages/design-system/templates/concept-lab/README.md), and you can open the lab from the repo root with `pnpm preview:concept-lab`.
+
+## Notes for this repo
+
+- Keep design-token decisions aligned with [docs/decisions/002-design-tokens.md](../decisions/002-design-tokens.md).
+- Treat [docs/features/design-system.md](./design-system.md) as the feature-level overview.
+- Reuse the branding and house rules from [packages/design-system/SKILL.md](../../packages/design-system/SKILL.md) when generating concepts.
+- Use [docs/features/design-system-review-checklist.md](./design-system-review-checklist.md) before promoting a concept into shared system primitives.

--- a/docs/features/design-system-review-checklist.md
+++ b/docs/features/design-system-review-checklist.md
@@ -1,0 +1,150 @@
+# Design System Review Checklist
+
+Use this checklist before a design concept becomes a shared component, variant, or token decision.
+
+## When to use it
+
+- After initial concept generation
+- Before implementation starts
+- Before promoting a local pattern into the shared design system
+- During design review for major UI changes
+
+## Review inputs
+
+Bring these artifacts into the review:
+
+- The concept or mock being reviewed
+- The user goal and success condition
+- The list of reused primitives
+- Any newly proposed primitives, variants, or tokens
+- Notes from the Copilot critique pass in [docs/features/design-system-copilot-prompts.md](./design-system-copilot-prompts.md)
+
+## Pass or fail rule
+
+The concept should not move forward unchanged if any of these are true:
+
+- It depends on hardcoded visual values that should come from tokens.
+- It introduces a one-off interaction pattern without a strong product reason.
+- It creates accessibility regressions in keyboard use, contrast, focus, or content order.
+- It duplicates an existing primitive with only cosmetic differences.
+- It looks strong in a mock but does not hold up in mobile, loading, empty, or error states.
+
+## Checklist
+
+### 1. User intent and content
+
+- Is the primary user action obvious within a few seconds?
+- Does the layout reflect the importance of the content instead of decorative balance?
+- Is the wording clear, specific, and aligned with the current product voice?
+- Are there places where design is compensating for weak content rather than improving it?
+
+### 2. Brand fit
+
+- Does the concept look like it belongs to this product family?
+- Does it follow the current brand rules for typography, tone, surfaces, and interaction cues?
+- Is it distinctive without inventing a parallel visual language?
+- If the concept feels fresh, is that freshness coming from composition rather than from breaking the system?
+
+### 3. Token discipline
+
+- Are color, spacing, typography, radius, shadow, and motion driven by existing tokens?
+- Are any values effectively new tokens disguised as local styling?
+- If new tokens are proposed, are they broadly reusable and clearly named?
+- Would a future rebrand or theme change still flow cleanly through this design?
+
+### 4. Component reuse
+
+- Which existing primitives are reused as-is?
+- Which proposed changes are true variants instead of new components?
+- Is there any local styling that should instead become a shared primitive?
+- Are we adding a new abstraction for a repeated problem, or just for this one screen?
+
+### 5. Interaction quality
+
+- Are primary, secondary, and destructive actions clearly distinguished?
+- Do hover, focus, pressed, disabled, loading, empty, success, and error states exist where needed?
+- Are interactions consistent with existing button, input, navigation, and feedback patterns?
+- Is anything visually attractive but confusing in real use?
+
+### 6. Accessibility
+
+- Does the reading order make sense without relying on visuals?
+- Can the UI be used fully by keyboard?
+- Are focus states visible and consistent?
+- Is contrast acceptable for text, controls, and boundaries?
+- Are target sizes and spacing usable on touch devices?
+- If motion is used, does it communicate something useful and remain tolerable?
+
+### 7. Responsive behavior
+
+- Does the concept preserve hierarchy on small screens?
+- Are important actions still visible without awkward scrolling?
+- Do cards, tables, menus, and filters adapt cleanly?
+- Does the design avoid desktop-only assumptions about width, hover, or persistent panels?
+
+### 8. System durability
+
+- Will this pattern still make sense when the product gains more content, states, or complexity?
+- Is the design resilient to longer copy, localization, or missing data?
+- Does it fail gracefully when content is sparse or unexpectedly dense?
+- Are we creating a pattern others can learn and reuse, or a brittle exception?
+
+### 9. Engineering cost
+
+- Is the design straightforward to implement with the current stack?
+- Does it require unusual layout or state management work that the user will not value?
+- Are there hidden costs in animation, responsiveness, or state handling?
+- Could a simpler version deliver most of the value with less risk?
+
+### 10. Promotion decision
+
+For each new pattern, decide one:
+
+- Token
+- Primitive
+- Component variant
+- Composed pattern
+- Local-only implementation
+
+If the team cannot classify it clearly, it is usually not ready to enter the shared system.
+
+## Review outcomes
+
+End each review with one of these outcomes:
+
+- Approve for prototype
+- Approve with required revisions
+- Keep local, do not systemize
+- Reject and return to concept exploration
+
+Record the specific reasons, not just the outcome.
+
+## Short scoring rubric
+
+Score each area from 1 to 5:
+
+| Area | 1 | 3 | 5 |
+| --- | --- | --- | --- |
+| User clarity | Confusing | Mostly clear | Immediately clear |
+| Brand fit | Off-system | Generally aligned | Strongly aligned |
+| Token discipline | Drifts often | Small exceptions | Fully disciplined |
+| Reuse potential | One-off | Some reuse | Strong candidate for shared use |
+| Accessibility | Significant gaps | Fixable gaps | Strong by default |
+| Buildability | Expensive or vague | Moderate | Efficient and clear |
+
+High visual appeal does not outweigh weak token discipline, poor reuse potential, or accessibility regressions.
+
+## Recommended review sequence
+
+1. Summarize the user goal in one sentence.
+2. Identify what is reused versus new.
+3. Run the checklist from user intent through engineering cost.
+4. Classify any new pattern before approving it.
+5. Record required changes and the review outcome.
+
+## Notes for this repo
+
+- Token decisions should stay aligned with [docs/decisions/002-design-tokens.md](../decisions/002-design-tokens.md).
+- The feature-level design-system overview lives in [docs/features/design-system.md](./design-system.md).
+- The Copilot generation and critique prompts live in [docs/features/design-system-copilot-prompts.md](./design-system-copilot-prompts.md).
+- Brand-specific rules and component guidance live in [packages/design-system/SKILL.md](../../packages/design-system/SKILL.md).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev:all": "turbo run dev",
     "build": "turbo run build",
     "lint": "turbo run lint",
-    "type-check": "turbo run type-check"
+    "type-check": "turbo run type-check",
+    "preview:concept-lab": "open 'packages/design-system/templates/concept-lab/ConceptLab.dc.html'"
   },
   "devDependencies": {
     "turbo": "2.10.5"

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "tsc",
     "type-check": "tsc --noEmit",
-    "lint": "echo 'No lint configured yet'"
+    "lint": "echo 'No lint configured yet'",
+    "preview:concept-lab": "open templates/concept-lab/ConceptLab.dc.html"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/design-system/templates/concept-lab/ConceptLab.dc.html
+++ b/packages/design-system/templates/concept-lab/ConceptLab.dc.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../marketing-landing/support.js"></script>
+</head>
+<body>
+<x-dc>
+        <h3>Client aftercare living page refresh</h3>
+        <p>Help a client understand what changed after today's treatment, follow the right routine for the next 48 hours, and feel reassured on mobile without adding a new navigation model.</p>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="./ds-base.js"></script>
+  <style>
+    body {
+      background:
+        radial-gradient(circle at top left, rgba(168, 146, 122, 0.16), transparent 32%),
+        linear-gradient(180deg, var(--surface-page) 0%, #efe9df 100%);
+      color: var(--text-body);
+    }
+
+    .lab-shell {
+      min-height: 100vh;
+      padding: var(--space-7);
+    }
+
+    .lab-frame {
+          <h3>Editorial reassurance</h3>
+          <p>Lead with the therapist note, then move into the updated routine and aftercare guidance. This keeps the page emotionally calm and familiar for clients who need confidence more than speed.</p>
+      display: grid;
+      gap: var(--space-6);
+    }
+            <div class="eyebrow">Therapist note</div>
+            <h3 style="margin-top: var(--space-3);">What changed today</h3>
+    .lab-panel,
+    .concept-card,
+    .score-card {
+      border: 1px solid var(--border-hairline);
+      border-radius: var(--radius-xl);
+      background: var(--surface-glass);
+      box-shadow: var(--shadow-glass);
+      backdrop-filter: var(--blur-panel);
+          <span class="pill">Reuses segmented toggle</span>
+          <span class="pill">Stronger intro block</span>
+
+    .lab-hero {
+      padding: var(--space-8);
+      display: grid;
+      gap: var(--space-5);
+    }
+
+          <h3>Action-first scan</h3>
+          <p>Start with a sticky next-step summary, then show the routine underneath. This favors clarity and fast scanning for repeat clients who just need to know what to do now.</p>
+    .concept-grid {
+      display: grid;
+      gap: var(--space-5);
+            <div class="eyebrow">Next 48 hours</div>
+            <h3 style="margin-top: var(--space-3);">Do this first</h3>
+    .hero-grid,
+    .review-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .concept-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+          <span class="pill">New summary card</span>
+          <span class="pill">Fast mobile scan</span>
+    .label,
+    .pill,
+    .score-label {
+      font-family: var(--font-mono);
+      text-transform: uppercase;
+    }
+
+          <h3>Recovery status hybrid</h3>
+          <p>Combine a calm editorial intro with a more explicit status block for redness, sensitivity, and product pauses. This is the most informative option, but it risks over-structuring a simple page.</p>
+    .score-label {
+      font-size: var(--type-eyebrow);
+      letter-spacing: var(--track-eyebrow);
+            <div class="eyebrow">Recovery status</div>
+            <h3 style="margin-top: var(--space-3);">Watch, avoid, restart</h3>
+    .eyebrow-row {
+      color: var(--text-accent);
+    }
+
+    .hero-copy {
+      max-width: 60ch;
+    }
+
+          <span class="pill">New status pattern</span>
+          <span class="pill">Prototype before promote</span>
+    .decision-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-3);
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 40px;
+      padding: 0 18px;
+              <p>Concept A feels the most native to the current living page voice; Concept C risks adding too much clinical framing.</p>
+      border: 1px solid var(--border-hairline);
+      background: rgba(255, 255, 255, 0.56);
+      letter-spacing: var(--track-button);
+      font-size: var(--type-label);
+      color: var(--text-strong);
+    }
+              <p>All three concepts can stay within current tokens; only the status treatment in Concept C may need a reusable tone variant.</p>
+    .lab-panel,
+    .concept-card,
+    .score-card {
+      padding: var(--space-6);
+    }
+
+              <p>The sticky 48-hour summary from Concept B is the strongest candidate for a shared composed pattern across aftercare flows.</p>
+    .concept-card p:last-child,
+    .score-card p:last-child {
+      margin-bottom: 0;
+    }
+
+    .label {
+              <p>Concept B creates the clearest mobile reading order, but its sticky summary must not hide the routine toggle or product cards.</p>
+      margin-bottom: var(--space-3);
+    }
+
+    .list {
+      margin: 0;
+      padding-left: 1.1rem;
+      display: grid;
+      gap: var(--space-2);
+        <h3>Write the smallest clean system change.</h3>
+        <p>For this example, keep the editorial intro local, promote the 48-hour summary as a composed pattern only if it repeats in other treatment flows, and treat the recovery-status block as experimental until another surface needs it.</p>
+    .concept-card {
+      display: grid;
+          <span class="pill">Primitive</span>
+          <span class="pill">Variant</span>
+          <span class="pill">Composed pattern: 48-hour summary</span>
+          <span class="pill">Local only: therapist note hero</span>
+
+        <p style="margin-top: var(--space-4);">Recommended winner: Concept B, softened with the calmer intro treatment from Concept A.</p>
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--border-hairline);
+      background: rgba(255, 255, 255, 0.62);
+      font-family: var(--font-mono);
+      font-size: var(--type-label);
+      letter-spacing: var(--track-label);
+      color: var(--text-accent);
+    }
+
+    .concept-preview {
+      min-height: 220px;
+      border-radius: var(--radius-lg);
+      border: 1px dashed var(--border-hairline);
+      background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(255, 255, 255, 0.24)),
+        radial-gradient(circle at top right, rgba(168, 146, 122, 0.20), transparent 40%);
+      padding: var(--space-5);
+      display: grid;
+      align-content: space-between;
+      gap: var(--space-4);
+    }
+
+    .preview-card {
+      border-radius: var(--radius-lg);
+      background: rgba(255, 255, 255, 0.68);
+      border: 1px solid var(--border-faint);
+      padding: var(--space-4);
+      box-shadow: 0 10px 28px rgba(40, 34, 28, 0.08);
+    }
+
+    .preview-lines {
+      display: grid;
+      gap: var(--space-2);
+    }
+
+    .preview-line {
+      height: 10px;
+      border-radius: var(--radius-pill);
+      background: rgba(87, 79, 67, 0.14);
+    }
+
+    .preview-line.short { width: 48%; }
+    .preview-line.mid { width: 68%; }
+    .preview-line.long { width: 88%; }
+
+    .score-grid {
+      display: grid;
+      gap: var(--space-3);
+    }
+
+    .score-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+      gap: var(--space-4);
+      padding-bottom: var(--space-3);
+      border-bottom: 1px solid var(--border-faint);
+    }
+
+    .score-row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .score-value {
+      min-width: 54px;
+      text-align: center;
+      border-radius: var(--radius-pill);
+      padding: 8px 12px;
+      background: rgba(255, 255, 255, 0.68);
+      border: 1px solid var(--border-hairline);
+      font-family: var(--font-mono);
+      letter-spacing: var(--track-label);
+      font-size: var(--type-label);
+      color: var(--text-strong);
+    }
+
+    .decision-row {
+      margin-top: var(--space-4);
+    }
+
+    @media (max-width: 980px) {
+      .hero-grid,
+      .review-grid,
+      .concept-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .lab-shell {
+        padding: var(--space-4);
+      }
+
+      .lab-hero,
+      .lab-panel,
+      .concept-card,
+      .score-card {
+        padding: var(--space-5);
+      }
+    }
+  </style>
+</helmet>
+<div class="lab-shell">
+  <div class="lab-frame">
+    <section class="lab-hero">
+      <div class="eyebrow-row">Concept lab</div>
+      <div class="hero-grid">
+        <div class="hero-copy">
+          <h1>Compare ideas before they become shared UI.</h1>
+          <p class="lede">Use this page as a disposable workspace for 2 to 3 directions, then decide what should become a token, primitive, variant, or stay local.</p>
+        </div>
+        <div class="lab-panel" style="padding: var(--space-5);">
+          <div class="label">Working loop</div>
+          <ol class="list" style="padding-left: 1.2rem; margin: 0;">
+            <li>Generate concepts with the workspace prompt files.</li>
+            <li>Paste the best ideas into the concept cards below.</li>
+            <li>Score them against brand fit, token discipline, reuse, and accessibility.</li>
+            <li>Record what should be systemized and what should stay local.</li>
+          </ol>
+        </div>
+      </div>
+      <div class="hero-actions">
+        <span class="pill">Generate concepts</span>
+        <span class="pill">Review concept</span>
+        <span class="pill">Systemize pattern</span>
+      </div>
+    </section>
+
+    <section class="review-grid">
+      <article class="lab-panel">
+        <div class="label">Brief</div>
+        <h3>Replace this with the real user job.</h3>
+        <p>Example: Help therapists scan a client's next action, confirm product choices, and spot issues fast on mobile without introducing a new navigation pattern.</p>
+      </article>
+      <article class="lab-panel">
+        <div class="label">Shared constraints</div>
+        <ul class="list">
+          <li>Reuse existing tokens for color, spacing, type, radius, shadow, and motion.</li>
+          <li>Prefer existing primitives before inventing a new component.</li>
+          <li>Do not approve a concept that only works in the ideal populated state.</li>
+          <li>Classify every new pattern before it enters the shared system.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="concept-grid">
+      <article class="concept-card">
+        <span class="concept-number">01</span>
+        <div>
+          <div class="label">Concept A</div>
+          <h3>Editorial overview</h3>
+          <p>Use this slot for a concise summary of the concept and the main behavioral bet it makes.</p>
+        </div>
+        <div class="concept-preview">
+          <div class="preview-card">
+            <div class="eyebrow">Primary section</div>
+            <h3 style="margin-top: var(--space-3);">Big summary first</h3>
+          </div>
+          <div class="preview-lines">
+            <div class="preview-line long"></div>
+            <div class="preview-line mid"></div>
+            <div class="preview-line short"></div>
+          </div>
+        </div>
+        <div class="pill-row">
+          <span class="pill">Reuses card</span>
+          <span class="pill">New hierarchy</span>
+        </div>
+      </article>
+
+      <article class="concept-card">
+        <span class="concept-number">02</span>
+        <div>
+          <div class="label">Concept B</div>
+          <h3>Utility-first scan</h3>
+          <p>Use this slot for the denser, faster-scanning option if the first concept is more expressive.</p>
+        </div>
+        <div class="concept-preview">
+          <div class="preview-card">
+            <div class="eyebrow">Action stack</div>
+            <h3 style="margin-top: var(--space-3);">Clear next steps</h3>
+          </div>
+          <div class="preview-lines">
+            <div class="preview-line long"></div>
+            <div class="preview-line long"></div>
+            <div class="preview-line mid"></div>
+          </div>
+        </div>
+        <div class="pill-row">
+          <span class="pill">Reuses buttons</span>
+          <span class="pill">Low engineering cost</span>
+        </div>
+      </article>
+
+      <article class="concept-card">
+        <span class="concept-number">03</span>
+        <div>
+          <div class="label">Concept C</div>
+          <h3>Hybrid direction</h3>
+          <p>Use this slot for a merged concept or a more experimental option worth pressure-testing.</p>
+        </div>
+        <div class="concept-preview">
+          <div class="preview-card">
+            <div class="eyebrow">Composed pattern</div>
+            <h3 style="margin-top: var(--space-3);">Shared if it repeats</h3>
+          </div>
+          <div class="preview-lines">
+            <div class="preview-line mid"></div>
+            <div class="preview-line short"></div>
+            <div class="preview-line long"></div>
+          </div>
+        </div>
+        <div class="pill-row">
+          <span class="pill">Review risk</span>
+          <span class="pill">Prototype before promote</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="review-grid">
+      <article class="score-card">
+        <div class="label">Scorecard</div>
+        <div class="score-grid">
+          <div class="score-row">
+            <div>
+              <div class="score-label">Brand fit</div>
+              <p>Does the concept belong to the current product family without inventing a parallel aesthetic?</p>
+            </div>
+            <div class="score-value">4/5</div>
+          </div>
+          <div class="score-row">
+            <div>
+              <div class="score-label">Token discipline</div>
+              <p>Are there any hidden one-off values that should be real tokens or existing variables?</p>
+            </div>
+            <div class="score-value">3/5</div>
+          </div>
+          <div class="score-row">
+            <div>
+              <div class="score-label">Reuse potential</div>
+              <p>Would the strongest part of this concept naturally become a shared primitive or composed pattern?</p>
+            </div>
+            <div class="score-value">4/5</div>
+          </div>
+          <div class="score-row">
+            <div>
+              <div class="score-label">Accessibility</div>
+              <p>Does the concept preserve hierarchy, focus, contrast, and mobile usability?</p>
+            </div>
+            <div class="score-value">4/5</div>
+          </div>
+        </div>
+      </article>
+
+      <article class="lab-panel">
+        <div class="label">Promotion decision</div>
+        <h3>Write the smallest clean system change.</h3>
+        <p>At the end of review, every new pattern should be classified as a token, primitive, component variant, composed pattern, or local-only implementation.</p>
+        <div class="decision-row">
+          <span class="pill">Token</span>
+          <span class="pill">Primitive</span>
+          <span class="pill">Variant</span>
+          <span class="pill">Composed pattern</span>
+          <span class="pill">Local only</span>
+        </div>
+        <p style="margin-top: var(--space-4);">If classification is unclear, the concept is usually not ready to enter the shared system.</p>
+      </article>
+    </section>
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/packages/design-system/templates/concept-lab/README.md
+++ b/packages/design-system/templates/concept-lab/README.md
@@ -1,0 +1,49 @@
+# Concept Lab
+
+The concept lab is a disposable workspace for design-system exploration before any idea becomes production UI.
+
+## What it is for
+
+- Compare 2 to 3 design directions for one page, flow, or component.
+- Capture the user brief, shared constraints, and review notes in one place.
+- Decide what should become a token, primitive, variant, composed pattern, or stay local.
+- Keep speculative work out of app code until the concept survives review.
+
+## Files
+
+- [ConceptLab.dc.html](./ConceptLab.dc.html): the starter concept-lab template.
+- [ds-base.js](./ds-base.js): loads the local design-system tokens and bundle into the template.
+
+## Recommended workflow
+
+1. Run the workspace prompts from `.github/prompts/`.
+2. Generate 2 to 3 directions for a single UI problem.
+3. Paste the strongest ideas into [ConceptLab.dc.html](./ConceptLab.dc.html).
+4. Review them against [docs/features/design-system-review-checklist.md](../../../docs/features/design-system-review-checklist.md).
+5. Promote only the smallest reusable parts into the shared system.
+
+## Included example
+
+The starter file includes a worked example for the client aftercare living page refresh. It compares three directions:
+
+- Editorial reassurance
+- Action-first scan
+- Recovery status hybrid
+
+Use that example as a pattern for how to document a real review, then replace it with the next concept you want to explore.
+
+## Preview
+
+From the repo root:
+
+```sh
+pnpm preview:concept-lab
+```
+
+From the design-system package:
+
+```sh
+pnpm preview:concept-lab
+```
+
+The preview command opens [ConceptLab.dc.html](./ConceptLab.dc.html) directly in the browser using the local static template setup already used by the other design-system templates.

--- a/packages/design-system/templates/concept-lab/ds-base.js
+++ b/packages/design-system/templates/concept-lab/ds-base.js
@@ -1,0 +1,15 @@
+// Loads this design system into the template. In a consuming project, point
+// base at the bound DS folder relative to this file (e.g. '_ds/<folder>' at
+// the project root, '../_ds/<folder>' one level down) - one line to edit.
+(() => {
+  const base = '../..';
+  for (const p of ["tokens/fonts.css","tokens/colors.css","tokens/typography.css","tokens/spacing.css","tokens/base.css","styles.css"]) {
+    const l = document.createElement('link');
+    l.rel = 'stylesheet'; l.href = base + '/' + p;
+    document.head.appendChild(l);
+  }
+  const s = document.createElement('script');
+  s.src = base + '/_ds_bundle.js';
+  s.onerror = () => console.error('ds-base.js: failed to load ' + s.src + ', if this is a consuming project, point the base line in ds-base.js at the bound _ds/<folder> tree relative to this page (e.g. _ds/<folder> at the project root, ../_ds/<folder> one level down); in a fresh design system this can just mean the bundle is not compiled yet');
+  document.head.appendChild(s);
+})();


### PR DESCRIPTION
Introduce a full design exploration workflow in-repo: three GitHub prompt commands for concept generation/review/systemization, a Copilot prompt pack, and a formal review checklist. Add a new disposable concept-lab template (with base asset loader and usage docs) under the design-system templates, and wire root/package scripts to preview it quickly via `pnpm preview:concept-lab`.