### PR TITLE
Guard Mapbox and add metadataBase fallback

### DIFF
--- a/apps/docs/app/NX/DesignSystem/components/Mapbox/Mapbox.tsx
+++ b/apps/docs/app/NX/DesignSystem/components/Mapbox/Mapbox.tsx
@@ -40,6 +40,10 @@ export default function Mapbox({ map }: T_MapboxProps) {
     return <Box>No location available</Box>;
   }
 
+  if (!MAPBOX_TOKEN) {
+    return <Box>Map unavailable</Box>;
+  }
+
   return (
     <Box
       sx={{ 

--- a/apps/docs/app/Virus/components/Mapbox/Mapbox.tsx
+++ b/apps/docs/app/Virus/components/Mapbox/Mapbox.tsx
@@ -40,6 +40,10 @@ export default function Mapbox({ map }: T_MapboxProps) {
     return <Box>No location available</Box>;
   }
 
+  if (!MAPBOX_TOKEN) {
+    return <Box>MAPBOX_TOKEN unavailable</Box>;
+  }
+
   return (
     <Box
       sx={{ 

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -8,12 +8,20 @@ import RequireAuthWrapper from './NX/Paywall/components/RequireAuthWrapper';
 
 const { manifestPath } = getDocsContext();
 const { siteName, description, favicon } = config;
+const metadataBase = (() => {
+  try {
+    return new URL(config.url);
+  } catch {
+    return new URL('http://localhost:3000');
+  }
+})();
 const configuredDesignSystem = config?.cartridges?.designSystem?.system;
 const designSystemId = typeof configuredDesignSystem === 'string' && configuredDesignSystem.trim()
   ? configuredDesignSystem.trim()
   : 'nx';
 
 export const metadata: Metadata = {
+  metadataBase,
   title: `${siteName}, ${description}`,
   description,
   icons: {


### PR DESCRIPTION
Add defensive handling for missing Mapbox configuration by returning a fallback UI when `MAPBOX_TOKEN` is not set in both docs Mapbox components. Also set `metadataBase` in the docs layout from `config.url`, with a localhost fallback when the URL is invalid, so metadata generation remains stable.