### PR TITLE
Add GitHub Action for Vercel build parity

### DIFF
--- a/.github/workflows/vercel-build-check.yml
+++ b/.github/workflows/vercel-build-check.yml
@@ -1,0 +1,44 @@
+name: Vercel Build Check
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: vercel-build-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vercel-build:
+    name: Vercel Build Parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Prepare pnpm (match vercel.json)
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.13.0 --activate
+          corepack pnpm --version
+
+      - name: Install dependencies (frozen lockfile)
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Build (match vercel.json)
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+        run: |
+          if [ -d apps/nx ]; then
+            corepack pnpm --dir apps/nx build
+          else
+            corepack pnpm build
+          fi


### PR DESCRIPTION
Add a CI workflow that runs on pushes and pull requests to mirror the Vercel build environment. It sets up Node.js 24, activates pnpm 11.13.0, installs with a frozen lockfile, and builds either `apps/nx` or the repo root so build issues can be caught before deployment.