### PR TITLE
Implement docs search functionality and update layout

### DIFF
--- a/apps/docs/app/NX/DesignSystem/components/NewspaperMasthead.tsx
+++ b/apps/docs/app/NX/DesignSystem/components/NewspaperMasthead.tsx
@@ -15,6 +15,7 @@ export interface NewspaperMastheadProps {
   sections?: Array<string | LinkItem>;
   menuItems?: NewspaperMastheadMenuItem[];
   utilityLinks?: LinkItem[];
+  utilityStart?: React.ReactNode;
 }
 
 function renderSection(item: string | LinkItem, index: number) {
@@ -89,10 +90,12 @@ export function NewspaperMasthead({
   sections = [],
   menuItems = [],
   utilityLinks = [],
+  utilityStart,
 }: NewspaperMastheadProps) {
   return (
     <header className="np-masthead" role="banner">
-      <div className="np-masthead-top-row">
+      <div className="np-masthead-top-row" style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '12px' }}>
+        {utilityStart ? <div className="np-masthead-utility-start" style={{ display: 'flex', alignItems: 'center' }}>{utilityStart}</div> : null}
         {utilityLinks.length > 0 ? (
           <nav aria-label="Utility" className="np-masthead-utility-nav">
             {utilityLinks.map((link) => (

--- a/apps/docs/app/NX/Search/SearchBar.tsx
+++ b/apps/docs/app/NX/Search/SearchBar.tsx
@@ -18,9 +18,10 @@ import { filterSearchEntries, highlightText, type SearchEntry } from './search-u
 
 type SearchBarProps = {
   entries: SearchEntry[];
+  compact?: boolean;
 };
 
-export default function SearchBar({ entries }: SearchBarProps) {
+export default function SearchBar({ entries, compact = false }: SearchBarProps) {
   const router = useRouter();
   const [query, setQuery] = React.useState('');
   const [open, setOpen] = React.useState(false);
@@ -63,11 +64,12 @@ export default function SearchBar({ entries }: SearchBarProps) {
   };
 
   const trimmedQuery = query.trim();
+  const popupWidth = compact ? 'min(960px, calc(100vw - 32px))' : '100%';
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', maxWidth: 960, mx: 'auto' }}>
+    <Box sx={{ position: 'relative', width: compact ? 260 : '100%', maxWidth: compact ? 260 : 960, mx: compact ? 0 : 'auto' }}>
       <TextField
-        fullWidth
+        fullWidth={!compact}
         variant="outlined"
         size="small"
         placeholder="Search titles, tags, and body text"
@@ -92,6 +94,7 @@ export default function SearchBar({ entries }: SearchBarProps) {
         sx={{
           background: 'background.paper',
           borderRadius: 999,
+          minWidth: compact ? 260 : undefined,
           '& .MuiOutlinedInput-root': {
             borderRadius: 999,
           },
@@ -105,7 +108,8 @@ export default function SearchBar({ entries }: SearchBarProps) {
             position: 'absolute',
             top: 'calc(100% + 8px)',
             left: 0,
-            right: 0,
+            width: popupWidth,
+            maxWidth: 'calc(100vw - 32px)',
             zIndex: 20,
             overflow: 'hidden',
             borderRadius: 3,

--- a/apps/docs/app/NX/Search/SearchBar.tsx
+++ b/apps/docs/app/NX/Search/SearchBar.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import * as React from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  Box,
+  Button,
+  ButtonBase,
+  InputAdornment,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import { filterSearchEntries, highlightText, type SearchEntry } from './search-utils';
+
+type SearchBarProps = {
+  entries: SearchEntry[];
+};
+
+export default function SearchBar({ entries }: SearchBarProps) {
+  const router = useRouter();
+  const [query, setQuery] = React.useState('');
+  const [open, setOpen] = React.useState(false);
+
+  const results = filterSearchEntries(entries, query, 3);
+  const allResults = filterSearchEntries(entries, query);
+  const hasMoreResults = query.trim().length > 0 && allResults.length > 3;
+
+  const goToSearchPage = React.useCallback(() => {
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    router.push(`/search?q=${encodeURIComponent(trimmed)}`);
+    setOpen(false);
+  }, [query, router]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      goToSearchPage();
+    }
+
+    if (event.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextValue = event.target.value;
+    setQuery(nextValue);
+    setOpen(nextValue.trim().length > 0);
+  };
+
+  const handleResultClick = (href: string) => {
+    setOpen(false);
+    router.push(href);
+  };
+
+  const trimmedQuery = query.trim();
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%', maxWidth: 960, mx: 'auto' }}>
+      <TextField
+        fullWidth
+        variant="outlined"
+        size="small"
+        placeholder="Search titles, tags, and body text"
+        value={query}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => {
+          if (trimmedQuery) {
+            setOpen(true);
+          }
+        }}
+        onBlur={() => {
+          window.setTimeout(() => setOpen(false), 120);
+        }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchOutlinedIcon fontSize="small" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          background: 'background.paper',
+          borderRadius: 999,
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 999,
+          },
+        }}
+      />
+
+      {open && trimmedQuery && results.length > 0 ? (
+        <Paper
+          elevation={8}
+          sx={{
+            position: 'absolute',
+            top: 'calc(100% + 8px)',
+            left: 0,
+            right: 0,
+            zIndex: 20,
+            overflow: 'hidden',
+            borderRadius: 3,
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Stack divider={<Box sx={{ borderTop: '1px solid', borderColor: 'divider' }} />}>
+            {results.map((result) => (
+              <ButtonBase
+                key={result.href}
+                component={Link}
+                href={result.href}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleResultClick(result.href);
+                }}
+                sx={{
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'left',
+                  p: 1.5,
+                }}
+              >
+                <Stack direction="row" spacing={1.5} alignItems="flex-start">
+                  {result.image ? (
+                    <Box
+                      component="img"
+                      src={result.image}
+                      alt={result.title}
+                      sx={{
+                        width: 64,
+                        height: 64,
+                        borderRadius: 2,
+                        objectFit: 'cover',
+                        flexShrink: 0,
+                        border: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    />
+                  ) : (
+                    <Box
+                      sx={{
+                        width: 64,
+                        height: 64,
+                        borderRadius: 2,
+                        display: 'grid',
+                        placeItems: 'center',
+                        flexShrink: 0,
+                        background: 'linear-gradient(180deg, rgba(245,247,250,1) 0%, rgba(232,236,242,1) 100%)',
+                        border: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    >
+                      <SearchOutlinedIcon fontSize="small" />
+                    </Box>
+                  )}
+
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+                      {highlightText(result.title, query)}
+                    </Typography>
+                    {result.description ? (
+                      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                        {highlightText(result.description, query)}
+                      </Typography>
+                    ) : null}
+                    {result.snippet ? (
+                      <Typography variant="body2" sx={{ mt: 0.5, color: 'text.primary' }}>
+                        {highlightText(result.snippet, query)}
+                      </Typography>
+                    ) : null}
+                  </Box>
+                </Stack>
+              </ButtonBase>
+            ))}
+
+            {hasMoreResults ? (
+              <Button
+                component={Link}
+                href={`/search?q=${encodeURIComponent(trimmedQuery)}`}
+                fullWidth
+                color="inherit"
+                sx={{
+                  justifyContent: 'space-between',
+                  borderRadius: 0,
+                  py: 1.25,
+                  px: 2,
+                  textTransform: 'none',
+                }}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => setOpen(false)}
+              >
+                <span>More results</span>
+                <span>{allResults.length}</span>
+              </Button>
+            ) : null}
+          </Stack>
+        </Paper>
+      ) : null}
+    </Box>
+  );
+}

--- a/apps/docs/app/NX/Search/SearchBar.tsx
+++ b/apps/docs/app/NX/Search/SearchBar.tsx
@@ -41,10 +41,16 @@ export default function SearchBar({ entries, compact = false }: SearchBarProps) 
     setOpen(false);
   }, [query, router]);
 
+  const goToResultsIfAny = React.useCallback(() => {
+    if (allResults.length > 0) {
+      goToSearchPage();
+    }
+  }, [allResults.length, goToSearchPage]);
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       event.preventDefault();
-      goToSearchPage();
+      goToResultsIfAny();
     }
 
     if (event.key === 'Escape') {

--- a/apps/docs/app/NX/Search/search-utils.tsx
+++ b/apps/docs/app/NX/Search/search-utils.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+
+export type SearchEntry = {
+  title: string;
+  slug: string;
+  href: string;
+  tags: string[];
+  description: string;
+  image?: string;
+  bodyText: string;
+  searchText: string;
+};
+
+export type SearchResult = SearchEntry & {
+  score: number;
+  snippet: string;
+  matchedField: 'title' | 'tags' | 'description' | 'body' | 'mixed';
+};
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function normalizeSearchText(value: string) {
+  return value
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function splitSearchTerms(query: string) {
+  return normalizeSearchText(query)
+    .split(' ')
+    .map((term) => term.trim())
+    .filter(Boolean);
+}
+
+export function stripMarkdown(value: string) {
+  return value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/^\s*#{1,6}\s+/gm, '')
+    .replace(/^\s*>\s?/gm, '')
+    .replace(/\[(.*?)\]\((.*?)\)/g, '$1')
+    .replace(/\[(?:[A-Za-z][^\]]*)\]/g, ' ')
+    .replace(/[\*_~>#-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function parseTags(value: unknown) {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => parseTags(item));
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  return [] as string[];
+}
+
+export function highlightText(text: string, query: string) {
+  const terms = splitSearchTerms(query);
+
+  if (terms.length === 0) {
+    return text;
+  }
+
+  const pattern = new RegExp(`(${terms.map(escapeRegExp).join('|')})`, 'ig');
+  const parts = text.split(pattern);
+
+  return parts.map((part, index) => {
+    if (!part) {
+      return null;
+    }
+
+    if (terms.some((term) => normalizeSearchText(part).includes(term))) {
+      return (
+        <mark
+          key={`${part}-${index}`}
+          style={{
+            background: 'rgba(255, 196, 0, 0.35)',
+            color: 'inherit',
+            borderRadius: '0.2em',
+            padding: '0 0.1em',
+          }}
+        >
+          {part}
+        </mark>
+      );
+    }
+
+    return <React.Fragment key={`${part}-${index}`}>{part}</React.Fragment>;
+  });
+}
+
+export function buildSnippet(text: string, query: string, maxLength = 180) {
+  const normalizedText = text.replace(/\s+/g, ' ').trim();
+  if (!normalizedText) {
+    return '';
+  }
+
+  const lowerText = normalizedText.toLowerCase();
+  const terms = splitSearchTerms(query);
+  const primaryTerm = terms[0] || '';
+
+  let startIndex = primaryTerm ? lowerText.indexOf(primaryTerm) : -1;
+  if (startIndex < 0 && terms.length > 1) {
+    for (const term of terms.slice(1)) {
+      const termIndex = lowerText.indexOf(term);
+      if (termIndex >= 0 && (startIndex < 0 || termIndex < startIndex)) {
+        startIndex = termIndex;
+      }
+    }
+  }
+
+  if (startIndex < 0) {
+    return normalizedText.length > maxLength
+      ? `${normalizedText.slice(0, maxLength).trim()}...`
+      : normalizedText;
+  }
+
+  const snippetStart = Math.max(0, startIndex - Math.floor(maxLength / 3));
+  const snippetEnd = Math.min(normalizedText.length, snippetStart + maxLength);
+  const snippet = normalizedText.slice(snippetStart, snippetEnd).trim();
+
+  return `${snippetStart > 0 ? '...' : ''}${snippet}${snippetEnd < normalizedText.length ? '...' : ''}`;
+}
+
+export function filterSearchEntries(entries: SearchEntry[], query: string, limit = Infinity) {
+  const terms = splitSearchTerms(query);
+
+  if (terms.length === 0) {
+    return [] as SearchResult[];
+  }
+
+  const scored = entries
+    .map((entry) => {
+      const title = normalizeSearchText(entry.title);
+      const tags = normalizeSearchText(entry.tags.join(' '));
+      const description = normalizeSearchText(entry.description || '');
+      const bodyText = normalizeSearchText(entry.bodyText);
+      const searchText = entry.searchText;
+
+      const matches = terms.every((term) => searchText.includes(term));
+      if (!matches) {
+        return null;
+      }
+
+      let score = 0;
+      let matchedField: SearchResult['matchedField'] = 'mixed';
+
+      if (terms.every((term) => title.includes(term))) {
+        score += 100;
+        matchedField = 'title';
+      } else if (title.includes(terms[0])) {
+        score += 80;
+        matchedField = 'title';
+      }
+
+      if (terms.every((term) => tags.includes(term))) {
+        score += 70;
+        matchedField = matchedField === 'title' ? 'mixed' : 'tags';
+      } else if (terms.some((term) => tags.includes(term))) {
+        score += 50;
+        matchedField = matchedField === 'title' ? 'mixed' : 'tags';
+      }
+
+      if (terms.some((term) => description.includes(term))) {
+        score += 30;
+      }
+
+      if (terms.some((term) => bodyText.includes(term))) {
+        score += 20;
+        if (matchedField === 'mixed') {
+          matchedField = 'body';
+        }
+      }
+
+      return {
+        ...entry,
+        score,
+        matchedField,
+        snippet: buildSnippet(entry.bodyText || entry.description || entry.title, query),
+      } satisfies SearchResult;
+    })
+    .filter(Boolean) as SearchResult[];
+
+  return scored
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+
+      return left.title.localeCompare(right.title);
+    })
+    .slice(0, limit);
+}

--- a/apps/docs/app/NX/lib/index.server.ts
+++ b/apps/docs/app/NX/lib/index.server.ts
@@ -5,6 +5,7 @@ import { serverUseAllMd } from './serverHooks/serverUseAllMd';
 import { serverUseSlugs } from './serverHooks/serverUseSlugs';
 import { serverUseRelated } from './serverHooks/serverUseRelated';
 import { serverUseRightRailCards } from './serverHooks/serverUseRightRailCards';
+import { serverUseSearchIndex } from './serverHooks/serverUseSearchIndex';
 import { getDocsContext } from './getDocsContext';
 import { getMeta } from './getMeta';
 
@@ -16,6 +17,7 @@ export {
     serverUseSlugs,
     serverUseRelated,
     serverUseRightRailCards,
+    serverUseSearchIndex,
     getDocsContext,
     getMeta,
 };

--- a/apps/docs/app/NX/lib/serverHooks/serverUseSearchIndex.ts
+++ b/apps/docs/app/NX/lib/serverHooks/serverUseSearchIndex.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { getDocsContext } from '../getDocsContext';
+import {
+  normalizeSearchText,
+  parseTags,
+  stripMarkdown,
+  type SearchEntry,
+} from '../../Search/search-utils';
+
+function deriveFallbackSlug(filePath: string, markdownRoot: string) {
+  const relativePath = path.relative(markdownRoot, filePath).replace(/\\/g, '/');
+  const withoutExtension = relativePath.replace(/\.md$/, '');
+  const segments = withoutExtension.split('/').filter(Boolean);
+
+  if (segments.length === 0) {
+    return '/';
+  }
+
+  if (segments[segments.length - 1] === 'index') {
+    segments.pop();
+  }
+
+  return `/${segments.join('/')}`.replace(/\/+/g, '/').replace(/\/$/, '') || '/';
+}
+
+function walkMarkdownFiles(dir: string, markdownRoot: string, entries: SearchEntry[]) {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+
+  const directoryEntries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of directoryEntries) {
+    const absolutePath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      walkMarkdownFiles(absolutePath, markdownRoot, entries);
+      continue;
+    }
+
+    if (!entry.name.endsWith('.md')) {
+      continue;
+    }
+
+    const markdown = fs.readFileSync(absolutePath, 'utf-8');
+    const { content, data } = matter(markdown);
+    const slug = typeof data.slug === 'string' && data.slug.trim()
+      ? data.slug.trim()
+      : deriveFallbackSlug(absolutePath, markdownRoot);
+    const title = typeof data.title === 'string' && data.title.trim()
+      ? data.title.trim()
+      : path.basename(entry.name, '.md');
+    const description = typeof data.description === 'string' ? data.description.trim() : '';
+    const image = typeof data.image === 'string' && data.image.trim() ? data.image.trim() : undefined;
+    const tags = parseTags(data.tags);
+    const bodyText = stripMarkdown(content);
+    const searchText = normalizeSearchText([
+      title,
+      description,
+      tags.join(' '),
+      slug,
+      bodyText,
+    ].filter(Boolean).join(' '));
+
+    entries.push({
+      title,
+      slug,
+      href: slug,
+      tags,
+      description,
+      image,
+      bodyText,
+      searchText,
+    });
+  }
+}
+
+export async function serverUseSearchIndex(): Promise<SearchEntry[]> {
+  const { markdownDir } = getDocsContext();
+  const entries: SearchEntry[] = [];
+  walkMarkdownFiles(markdownDir, markdownDir, entries);
+
+  return entries.sort((left, right) => left.title.localeCompare(right.title));
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -5,10 +5,11 @@ import type { Metadata } from "next";
 import { NewspaperShell } from "@nx/newspaper";
 import type { MastheadMenuItem } from "@nx/newspaper";
 import config from '../public/config.json';
-import { getDocsContext, serverUseNav } from './NX/lib/index.server';
+import { getDocsContext, serverUseNav, serverUseSearchIndex } from './NX/lib/index.server';
 import { UbereduxProvider } from './NX/Uberedux';
 import RequireAuthWrapper from './NX/Paywall/components/RequireAuthWrapper';
 import { NewspaperMasthead } from './NX/DesignSystem/components/NewspaperMasthead';
+import SearchBar from './NX/Search/SearchBar';
 
 const { manifestPath } = getDocsContext();
 const { siteName, description, favicon } = config;
@@ -72,7 +73,16 @@ export default async function RootLayout({
 
   const paywall = config.cartridges?.paywall?.enabled === true;
   const navItems = await serverUseNav();
+  const searchEntries = await serverUseSearchIndex();
   const mastheadMenu = toMastheadMenu(navItems as RawNavItem[]);
+  const content = (
+    <>
+      <div className="wrapper-inner" style={{ paddingTop: 16 }}>
+        <SearchBar entries={searchEntries} />
+      </div>
+      {children}
+    </>
+  );
 
   return (
     <html lang="en" data-design-system={designSystemId}>
@@ -96,9 +106,9 @@ export default async function RootLayout({
           <div className="wrapper">
             <UbereduxProvider config={config}>
               {paywall ? (
-                <RequireAuthWrapper config={config}>{children}</RequireAuthWrapper>
+                <RequireAuthWrapper config={config}>{content}</RequireAuthWrapper>
               ) : (
-                children
+                content
               )}
             </UbereduxProvider>
           </div>

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -75,14 +75,7 @@ export default async function RootLayout({
   const navItems = await serverUseNav();
   const searchEntries = await serverUseSearchIndex();
   const mastheadMenu = toMastheadMenu(navItems as RawNavItem[]);
-  const content = (
-    <>
-      <div className="wrapper-inner" style={{ paddingTop: 16 }}>
-        <SearchBar entries={searchEntries} />
-      </div>
-      {children}
-    </>
-  );
+  const utilityStart = <SearchBar entries={searchEntries} compact />;
 
   return (
     <html lang="en" data-design-system={designSystemId}>
@@ -101,15 +94,12 @@ export default async function RootLayout({
             title={siteName}
             strapline={description}
             menuItems={mastheadMenu}
+            utilityStart={utilityStart}
             utilityLinks={[{ label: "Home", href: "/" }]}
           />
           <div className="wrapper">
             <UbereduxProvider config={config}>
-              {paywall ? (
-                <RequireAuthWrapper config={config}>{content}</RequireAuthWrapper>
-              ) : (
-                content
-              )}
+              {paywall ? <RequireAuthWrapper config={config}>{children}</RequireAuthWrapper> : children}
             </UbereduxProvider>
           </div>
         </NewspaperShell>

--- a/apps/docs/app/search/page.tsx
+++ b/apps/docs/app/search/page.tsx
@@ -1,0 +1,164 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  Box,
+  Chip,
+  Container,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { getDocsContext, getMeta, serverUseSearchIndex } from '../NX/lib/index.server';
+import {
+  filterSearchEntries,
+  highlightText,
+  type SearchResult,
+} from '../NX/Search/search-utils';
+
+type SearchParams = {
+  q?: string | string[];
+};
+
+type SearchPageProps = {
+  searchParams?: SearchParams | Promise<SearchParams>;
+};
+
+function resolveSearchParams(searchParams?: SearchParams | Promise<SearchParams>) {
+  return Promise.resolve(searchParams ?? {});
+}
+
+export async function generateMetadata({ searchParams }: SearchPageProps): Promise<Metadata> {
+  const resolvedSearchParams = await resolveSearchParams(searchParams);
+  const query = typeof resolvedSearchParams?.q === 'string' ? resolvedSearchParams.q.trim() : '';
+  const { config } = getDocsContext();
+  const baseUrl = (config.url || '').replace(/\/$/, '');
+
+  return getMeta({
+    siteName: config.siteName,
+    title: query ? `Search: ${query}` : 'Search',
+    description: query ? `Search results for ${query}` : config.description,
+    image: config.images?.light || config.images?.dark,
+    url: `${baseUrl}/search${query ? `?q=${encodeURIComponent(query)}` : ''}`,
+  });
+}
+
+function SearchResultCard({ result, query }: { result: SearchResult; query: string }) {
+  return (
+    <Paper
+      component={Link}
+      href={result.href}
+      variant="outlined"
+      sx={{
+        overflow: 'hidden',
+        borderRadius: 3,
+        textDecoration: 'none',
+        color: 'inherit',
+        display: 'block',
+        transition: 'transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          boxShadow: 3,
+          borderColor: 'text.primary',
+        },
+      }}
+    >
+      {result.image ? (
+        <Box
+          component="img"
+          src={result.image}
+          alt={result.title}
+          sx={{
+            width: '100%',
+            height: 200,
+            objectFit: 'cover',
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+          }}
+        />
+      ) : null}
+
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+          {highlightText(result.title, query)}
+        </Typography>
+
+        {result.description ? (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
+            {highlightText(result.description, query)}
+          </Typography>
+        ) : null}
+
+        {result.snippet ? (
+          <Typography variant="body2" sx={{ mt: 1, color: 'text.primary' }}>
+            {highlightText(result.snippet, query)}
+          </Typography>
+        ) : null}
+
+        {result.tags.length > 0 ? (
+          <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" sx={{ mt: 1.5 }}>
+            {result.tags.slice(0, 6).map((tag) => (
+              <Chip key={tag} label={highlightText(tag, query)} size="small" variant="outlined" />
+            ))}
+          </Stack>
+        ) : null}
+      </Box>
+    </Paper>
+  );
+}
+
+export default async function SearchPage({ searchParams }: SearchPageProps) {
+  const resolvedSearchParams = await resolveSearchParams(searchParams);
+  const query = typeof resolvedSearchParams?.q === 'string' ? resolvedSearchParams.q.trim() : '';
+  const entries = await serverUseSearchIndex();
+  const results = query ? filterSearchEntries(entries, query) : [];
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 4 }}>
+      <Box sx={{ mb: 3 }}>
+        <Typography component="h1" variant="h3" sx={{ fontWeight: 400, lineHeight: 1.05 }}>
+          Search
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mt: 1, maxWidth: '72ch' }}>
+          {query
+            ? `${results.length} result${results.length === 1 ? '' : 's'} for “${query}”.`
+            : 'Use the search field to find matches across titles, tags, and body text.'}
+        </Typography>
+      </Box>
+
+      {query ? (
+        results.length > 0 ? (
+          <Box
+            sx={{
+              display: 'grid',
+              gap: 2,
+              gridTemplateColumns: { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' },
+              alignItems: 'start',
+            }}
+          >
+            {results.map((result) => (
+              <SearchResultCard key={result.href} result={result} query={query} />
+            ))}
+          </Box>
+        ) : (
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+            <Typography variant="h6" sx={{ fontWeight: 600 }}>
+              No matches found
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              Try a different title, tag, or phrase from the body text.
+            </Typography>
+          </Paper>
+        )
+      ) : (
+        <Paper variant="outlined" sx={{ p: 3, borderRadius: 3 }}>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            Start typing in the search field above
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            Results will appear as cards once you run a search.
+          </Typography>
+        </Paper>
+      )}
+    </Container>
+  );
+}

--- a/apps/docs/app/search/page.tsx
+++ b/apps/docs/app/search/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import {
   Box,
   Chip,
@@ -45,7 +44,7 @@ export async function generateMetadata({ searchParams }: SearchPageProps): Promi
 function SearchResultCard({ result, query }: { result: SearchResult; query: string }) {
   return (
     <Paper
-      component={Link}
+      component="a"
       href={result.href}
       variant="outlined"
       sx={{

--- a/apps/docs/public/markdown/apps/v3.md
+++ b/apps/docs/public/markdown/apps/v3.md
@@ -16,7 +16,7 @@ icon: web
 ## Documentation
 
 - [NX Guide](/guides/nx)
-- [API + TypeScript Guide](/techstack/api-typescript)
+- [API + TypeScript Guide](/architecture/tech-stack/api-typescript)
 - [Testing Guide](/guides/testing)
 - [Theme Guide](/guides/theme)
 

--- a/apps/docs/public/markdown/architecture/tech-stack/api-typescript.md
+++ b/apps/docs/public/markdown/architecture/tech-stack/api-typescript.md
@@ -1,9 +1,9 @@
 ---
 order: 41
-slug: /techstack/api-typescript
+slug: /architecture/tech-stack/api-typescript
 title: API + TypeScript
 description: Guide to NX API routes, shared utilities, contracts, and tests
-tags: docs, nx, api, typescript
+tags: docs, nx, api, typescript, architecture, techstack
 icon: api
 ---
 # API + TypeScript Guide

--- a/apps/docs/public/markdown/guides/index.md
+++ b/apps/docs/public/markdown/guides/index.md
@@ -14,7 +14,7 @@ This folder is the canonical location for repository documentation.
 ## Core Guides
 
 - [NX Guide](./nx.md)
-- [API + TypeScript Guide](../techstack/api-typescript.md)
+- [API + TypeScript Guide](../architecture/tech-stack/api-typescript.md)
 - [Testing Guide](./testing.md)
 - [Theme Guide](./theme.md)
 

--- a/apps/docs/public/markdown/techstack/index.md
+++ b/apps/docs/public/markdown/techstack/index.md
@@ -1,9 +1,0 @@
----
-order: 40
-slug: /techstack
-title: Tech Stack
-description: Technical guides for platform architecture and implementation
-tags: docs, techstack, nx
-icon: api
----
-[PageLink title="API + TypeScript" description="Guide to NX API routes, shared utilities, contracts, and tests" url="/techstack/api-typescript"]


### PR DESCRIPTION
This pull request introduces a new full-text search feature for the documentation site, including backend indexing of markdown files and a frontend search bar integrated into the masthead. The most important changes are the implementation of a server-side search index, a client-side search UI, and the necessary wiring to display search functionality in the site's header.

**Search Indexing and Backend Integration:**
- Added `serverUseSearchIndex` to recursively index all markdown files, extracting metadata and normalized search text for each document to enable efficient search queries.
- Exported `serverUseSearchIndex` from the main server library for use in the application. [[1]](diffhunk://#diff-0026575567cb48bcb0dcfe916fb837f094b892dd067d579ccaecfe1fab301391R8) [[2]](diffhunk://#diff-0026575567cb48bcb0dcfe916fb837f094b892dd067d579ccaecfe1fab301391R20)

**Frontend Search UI:**
- Implemented a new `SearchBar` React component that provides instant search suggestions, result highlighting, and navigation to a search results page.
- Added search utility functions for text normalization, markdown stripping, tag parsing, snippet generation, and result scoring.

**Masthead Integration and Layout Updates:**
- Extended the `NewspaperMasthead` component and its props to support a `utilityStart` slot for custom content, and updated its layout to accommodate the search bar. [[1]](diffhunk://#diff-dd62b564ec05ab4666b6ce70b9d4c3e38aefd929e4ae704c4fb1d5ab0ea48fc5R18) [[2]](diffhunk://#diff-dd62b564ec05ab4666b6ce70b9d4c3e38aefd929e4ae704c4fb1d5ab0ea48fc5R93-R98)
- Fetched the search index in the main layout, instantiated the search bar with search entries, and passed it to the masthead for display across all pages. [[1]](diffhunk://#diff-c8fb8339570a5305809be7c618e14705fd86390dc278e6ce8ba224a7bc8b0c3cL8-R12) [[2]](diffhunk://#diff-c8fb8339570a5305809be7c618e14705fd86390dc278e6ce8ba224a7bc8b0c3cR76-R78) [[3]](diffhunk://#diff-c8fb8339570a5305809be7c618e14705fd86390dc278e6ce8ba224a7bc8b0c3cR97-R102)