### PR TITLE
Rename package to nx, update README links, and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div>
     <h1 style="display: flex; align-items: center; gap: 8px;">
-        <a href="https://goldlabel.pro/nx" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+        <a href="https://nx.goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
         <img
-            src="apps/docs/public/docs/media/nx-icon.png"
+            src="https://nx.goldlabel.pro/nx/png/favicon.png"
             width="24"
             height="24"
         />

--- a/README.md
+++ b/README.md
@@ -9,29 +9,17 @@
         </a>
         <span>NX° Turbo</span>
     </h1>
+
+
+    
 </div>
 
-## NX° Turbo
+## Docs Links
 
-NX° turborepo implementation
+- https://docs.goldlabel.pro
+- https://docs.goldlabel.pro/NX
+- https://docs.goldlabel.pro/Virus
+- https://docs.goldlabel.pro/account
+- https://docs.goldlabel.pro/search
 
-- [Home](apps/docs/public/docs/README.md)
-- [NX Guide](apps/docs/public/docs/nx.md)
-- [NX Guide](apps/docs/public/docs/nx.md)
-- [API + TypeScript Guide](apps/docs/public/docs/api-typescript.md)
-- [Testing Guide](apps/docs/public/docs/testing.md)
-- [Theme Guide](apps/docs/public/docs/theme.md)
 
-## Apps
-
-- [Overview](apps/docs/public/docs/apps/v3.md)
-- [NX Runtime Notes](apps/docs/public/docs/apps/nx-runtime.md)
-- [NX Shortcodes](apps/docs/public/docs/apps/nx-shortcodes.md)
-- [NX CleverText](apps/docs/public/docs/apps/nx-clevertext.md)
-- [NX Chatbot Flash Notes](apps/docs/public/docs/apps/nx-chatbot.md)
-
-## Packages
-
-### packages/ui
-
-- [Overview](apps/docs/public/docs/packages/design-system.md)

--- a/package.json
+++ b/package.json
@@ -7,16 +7,14 @@
   },
   "private": true,
   "scripts": {
-    "dev": "turbo run dev storybook --filter=!python",
-    "dev:all": "turbo run dev",
+    "dev": "turbo run dev",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "ci:github": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && NEXT_TELEMETRY_DISABLED=1 sh -c 'if [ -d apps/nx ]; then corepack pnpm --dir apps/nx build; else corepack pnpm build; fi'",
     "ci:full": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && corepack pnpm lint && corepack pnpm type-check && corepack pnpm -r --if-present test && corepack pnpm build",
     "storybook": "turbo run storybook --filter=@nx/themes-storybook",
-    "build-storybook": "turbo run build-storybook --filter=@nx/themes-storybook",
-    "preview:concept-lab": "open 'packages/ui/templates/concept-lab/ConceptLab.dc.html'"
+    "build-storybook": "turbo run build-storybook --filter=@nx/themes-storybook"
   },
   "devDependencies": {
     "turbo": "2.10.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nx-turbo",
-  "version": "1.5.1",
+  "name": "nx",
+  "version": "1.5.2",
   "packageManager": "pnpm@11.13.0",
   "engines": {
     "node": ">=20 <25"


### PR DESCRIPTION
This pull request updates project metadata and documentation to reflect new branding and improve clarity. The most important changes include renaming the project, updating documentation links and images, and cleaning up unused documentation sections.

**Project branding and metadata updates:**

* Renamed the project in `package.json` from `"nx-turbo"` to `"nx"` and incremented the version to `1.5.2` to reflect the new branding.

**Documentation improvements:**

* Updated the main logo link and image in `README.md` to point to the new domain and favicon.
* Replaced the old list of internal documentation links in `README.md` with a concise set of external docs URLs for easier navigation.
* Removed redundant or outdated documentation sections and links from the `README.md` for clarity.

**Script and configuration cleanup:**

* Simplified `dev` and `storybook` scripts in `package.json` by removing unused or redundant commands.