### PR TITLE
Add root-level test harness for monorepo with pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "dev": "turbo run dev",
     "build": "turbo run build",
     "lint": "turbo run lint",
+    "test": "node ./tests/run-monorepo-tests.mjs",
     "type-check": "turbo run type-check",
     "ci:github": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && NEXT_TELEMETRY_DISABLED=1 sh -c 'if [ -d apps/nx ]; then corepack pnpm --dir apps/nx build; else corepack pnpm build; fi'",
-    "ci:full": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && corepack pnpm lint && corepack pnpm type-check && corepack pnpm -r --if-present test && corepack pnpm build"
+    "ci:full": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && corepack pnpm lint && corepack pnpm type-check && corepack pnpm test && corepack pnpm build"
   },
   "devDependencies": {
     "turbo": "2.10.7"

--- a/tests/monorepo.test.mjs
+++ b/tests/monorepo.test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import test from 'node:test';
+
+test('workspace roots exist', () => {
+  assert.equal(existsSync('apps'), true);
+  assert.equal(existsSync('packages'), true);
+});

--- a/tests/run-monorepo-tests.mjs
+++ b/tests/run-monorepo-tests.mjs
@@ -1,0 +1,15 @@
+import { spawnSync } from 'node:child_process';
+
+const run = (command, args) => {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+run('pnpm', ['--filter', './apps/*', '--filter', './packages/*', '-r', '--if-present', 'test']);
+run('node', ['--test', './tests/monorepo.test.mjs']);


### PR DESCRIPTION
This pull request introduces a basic test runner for the monorepo and updates related scripts to ensure all package and workspace-level tests are executed consistently in CI and development workflows.

**Testing infrastructure improvements:**

* Added a new script `tests/run-monorepo-tests.mjs` to run all package tests and a workspace-level test using `pnpm` and Node.js, ensuring tests in both `apps` and `packages` directories are executed.
* Introduced a simple workspace-level test in `tests/monorepo.test.mjs` to verify that the `apps` and `packages` directories exist.

**Script and CI workflow updates:**

* Added a `test` script to `package.json` that runs the new monorepo test runner.
* Updated the `ci:full` script in `package.json` to use the new `test` script, ensuring all tests are executed during CI runs.