### PR TITLE
Add docs and expand README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 <div>
-    <h1 style="display: flex; align-items: center; gap: 8px;">
+    <h1 style="display: flex; align-items: center; gap: 4px;">
         <a href="https://nx.goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
         <img
             src="https://nx.goldlabel.pro/nx/png/favicon.png"
-            width="75"
-            height="75"
+            width="32"
+            height="32"
         />
         </a>
-        <span>NX° Turbo</span>
+        <span>NX°</span>
     </h1>
 </div>
 
-[Docs](./docs/README.md)
+> NX° is a digital platform for exploring and sharing stories, ideas, and creative work across a network of projects and communities.
+
+- Who: NX° is built for creators, collaborators, and audiences who want a flexible space to publish, discover, and engage with rich multimedia content.
+- What: It combines editorial content, interactive media, and a modern web experience into one cohesive product.
+- When: It is designed for ongoing use as a living publishing platform, supporting new content and updates over time.
+- Where: It runs as a web-based experience, with content delivered through a Next.js application and supporting services.
+- Why: NX° exists to help people connect ideas, tell stories, and build shared experiences in a scalable, accessible way.
+
+## Docs
+
+- [Overview](./docs/README.md)
+- [Tech Stack](./docs/techstack.md)
+- [Apps and Packages](./docs/apps.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# NX°
+
+NX° is a digital platform for exploring and sharing stories, ideas, and creative work across a network of projects and communities.
+
+- Who: NX° is built for creators, collaborators, and audiences who want a flexible space to publish, discover, and engage with rich multimedia content.
+- What: It combines editorial content, interactive media, and a modern web experience into one cohesive product.
+- When: It is designed for ongoing use as a living publishing platform, supporting new content and updates over time.
+- Where: It runs as a web-based experience, with content delivered through a Next.js application and supporting services.
+- Why: NX° exists to help people connect ideas, tell stories, and build shared experiences in a scalable, accessible way.
+
+## Table of Contents
+
+- [Overview](README.md)
+- [Tech Stack](techstack.md)
+- [Apps and Packages](apps.md)

--- a/docs/apps-packages.md
+++ b/docs/apps-packages.md
@@ -1,0 +1,21 @@
+# Apps and Packages
+
+This monorepo is organized into two main kinds of workspaces: apps and packages.
+
+## Apps
+Apps are deployable products or experiences. They contain the user-facing application code and are the places where end-to-end features are assembled.
+
+In this repository, the main app is located under [apps/nx](../apps/nx), and it represents the primary web experience.
+
+## Packages
+Packages are reusable building blocks shared across apps or internal tooling. They are typically smaller, focused modules that can be imported by multiple parts of the monorepo.
+
+Examples in this repository include shared libraries under [packages](../packages), such as the Firebase and Flash packages.
+
+## How to think about them
+- Use apps for product experiences and deployment targets.
+- Use packages for shared logic, UI, utilities, or integrations.
+- Keep app-specific code in apps and reusable logic in packages.
+
+## Rule of thumb
+If something is meant to be used by more than one app, it likely belongs in a package. If it is specific to one product experience, it likely belongs in an app.

--- a/docs/techstack.md
+++ b/docs/techstack.md
@@ -1,0 +1,26 @@
+# Tech Stack Overview
+
+This monorepo uses a modern web stack centered on Next.js, TypeScript, and Turbo.
+
+## Core
+- Node.js and pnpm for package management and workspace orchestration
+- TypeScript for application and shared library code
+- Turbo for monorepo task orchestration and build pipelines
+
+## App Layer
+- Next.js for the main web application in apps/nx
+- React and React DOM for UI rendering
+- CSS and component-based styling support for the app experience
+
+## Data and Services
+- Firebase for backend and app services integration
+- Gray-matter and markdown-driven content handling for CMS-style content
+
+## Tooling
+- Jest for unit and integration testing
+- ESLint for code quality
+- Vercel deployment configuration for the web app
+
+## Notes
+- This overview is intentionally concise and easy to update as the stack evolves.
+


### PR DESCRIPTION
Add project documentation and expand the top-level README. New files: docs/README.md, docs/apps-packages.md, and docs/techstack.md provide an overview, apps/packages guidance, and a concise tech stack. Update README.md to reduce the logo size, shorten the product name to “NX°”, and add a descriptive project summary with links to the new docs.