### PR TITLE
Refresh docs branding and add client test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,10 @@
     </h1>
 </div>
 
-> NX° is a digital platform for exploring and sharing stories, ideas, and creative work across a network of projects and communities.
-
-- Who: NX° is built for creators, collaborators, and audiences who want a flexible space to publish, discover, and engage with rich multimedia content.
-- What: It combines editorial content, interactive media, and a modern web experience into one cohesive product.
-- When: It is designed for ongoing use as a living publishing platform, supporting new content and updates over time.
-- Where: It runs as a web-based experience, with content delivered through a Next.js application and supporting services.
-- Why: NX° exists to help people connect ideas, tell stories, and build shared experiences in a scalable, accessible way.
+> NX° is a JavaScript platform for creating apps across a network of projects and needs. Built for creators, coders, collaborators, and audiences who need a flexible space to publish, discover, and engage with rich content [more...](./docs/README.md)
 
 ## Docs
 
 - [Overview](./docs/README.md)
 - [Tech Stack](./docs/techstack.md)
 - [Apps and Packages](./docs/apps.md)
-
-
-
-{
-  "name": "Gisela Dorward",
-  "routineContext": "Would like a gentle routine that deeply hydrates mature skin, improves comfort and radiance, and supports skin health without using harsh active ingredients.",
-  "skinOverview": "Mature dry skin with reduced elasticity, pronounced fine lines, and some age-related pigmentation. The skin would benefit from intensive hydration, barrier repair, and nourishing ingredients to improve softness and luminosity.",
-  "personalNotes": "Enjoys tending to her rose garden and spends a lot of time outdoors in spring and summer. Wants a simple routine that's easy to follow and doesn't involve too many products.",
-  "skinType": "Dry",
-  "concerns": [
-    "Wrinkles",
-    "Pigmentation",
-    "Dehydration",
-    "Aging"
-  ],
-  "dateOfBirth": "03/06/1951",
-  "pregnant": false,
-  "breastfeeding": false
-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,24 @@
+<div>
+    <h1 style="display: flex; align-items: center; gap: 4px;">
+        <a href="https://nx.goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+        <img
+            src="https://nx.goldlabel.pro/nx/png/favicon.png"
+            width="32"
+            height="32"
+        />
+        </a>
+        <span>NX° Docs</span>
+    </h1>
+</div>
+
 # NX°
 
-NX° is a digital platform for exploring and sharing stories, ideas, and creative work across a network of projects and communities.
+NX° is a JavaScript platform for creating apps across a network of projects and needs. Built for creators, coders, collaborators, and audiences who need a flexible space to publish, discover, and engage with rich content 
 
-- Who: NX° is built for creators, collaborators, and audiences who want a flexible space to publish, discover, and engage with rich multimedia content.
-- What: It combines editorial content, interactive media, and a modern web experience into one cohesive product.
-- When: It is designed for ongoing use as a living publishing platform, supporting new content and updates over time.
-- Where: It runs as a web-based experience, with content delivered through a Next.js application and supporting services.
-- Why: NX° exists to help people connect ideas, tell stories, and build shared experiences in a scalable, accessible way.
+- What:
+- When:
+- Where:
+- Why:
 
 ## Table of Contents
 

--- a/docs/apps-packages.md
+++ b/docs/apps-packages.md
@@ -1,3 +1,16 @@
+<div>
+    <h1 style="display: flex; align-items: center; gap: 4px;">
+        <a href="https://nx.goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+        <img
+            src="https://nx.goldlabel.pro/nx/png/favicon.png"
+            width="32"
+            height="32"
+        />
+        </a>
+        <span>NX° Apps and Packages</span>
+    </h1>
+</div>
+
 # Apps and Packages
 
 This monorepo is organized into two main kinds of workspaces: apps and packages.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,3 +1,16 @@
+<div>
+    <h1 style="display: flex; align-items: center; gap: 4px;">
+        <a href="https://nx.goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+        <img
+            src="https://nx.goldlabel.pro/nx/png/favicon.png"
+            width="32"
+            height="32"
+        />
+        </a>
+        <span>NX° Developer</span>
+    </h1>
+</div>
+
 ## Developer
 
 As a logged-in GitHub user, go to [github.com/goldlabelapps/nx](https://github.com/goldlabelapps/nx) and click "Use this template."

--- a/docs/techstack.md
+++ b/docs/techstack.md
@@ -1,3 +1,16 @@
+<div>
+    <h1 style="display: flex; align-items: center; gap: 4px;">
+        <a href="https://nx.goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
+        <img
+            src="https://nx.goldlabel.pro/nx/png/favicon.png"
+            width="32"
+            height="32"
+        />
+        </a>
+        <span>NX° Tech Stack Overview</span>
+    </h1>
+</div>
+
 # Tech Stack Overview
 
 This monorepo uses a modern web stack centered on Next.js, TypeScript, and Turbo.

--- a/docs/testdata/leida-client.json
+++ b/docs/testdata/leida-client.json
@@ -1,0 +1,16 @@
+{
+    "name": "Gisela Dorward",
+    "routineContext": "Would like a gentle routine that deeply hydrates mature skin, improves comfort and radiance, and supports skin health without using harsh active ingredients.",
+    "skinOverview": "Mature dry skin with reduced elasticity, pronounced fine lines, and some age-related pigmentation. The skin would benefit from intensive hydration, barrier repair, and nourishing ingredients to improve softness and luminosity.",
+    "personalNotes": "Enjoys tending to her rose garden and spends a lot of time outdoors in spring and summer. Wants a simple routine that's easy to follow and doesn't involve too many products.",
+    "skinType": "Dry",
+    "concerns": [
+        "Wrinkles",
+        "Pigmentation",
+        "Dehydration",
+        "Aging"
+    ],
+    "dateOfBirth": "03/06/1951",
+    "pregnant": false,
+    "breastfeeding": false
+}


### PR DESCRIPTION
Updated the root and docs README copy to a new platform description, with the root README now linking to docs for more details. Added consistent NX° branded header blocks to key docs pages (README, apps/packages, developer, tech stack). Removed the stray JSON payload from README and stored it as structured test data in `docs/testdata/leida-client.json`.