### PR TITLE
Add site-layout CSS and restore footer/sidebar

### DIFF
--- a/apps/nx/app/[[...slug]]/page.tsx
+++ b/apps/nx/app/[[...slug]]/page.tsx
@@ -128,10 +128,10 @@ export default async function Page({ params }: T_PageProps) {
                     featuredImage={featuredImage}
                 />
 
-                {/* <SiteSidebar /> */}
+                <SiteSidebar />
             </main>
 
-            {/* <SiteFooter /> */}
+            <SiteFooter />
         </div>
     );
 }

--- a/apps/nx/app/components/SiteFooter.tsx
+++ b/apps/nx/app/components/SiteFooter.tsx
@@ -1,41 +1,39 @@
 export default function SiteFooter() {
 	return (
 		<footer className="site-footer">
-			<div className="site-footer-top">
-				<nav className="site-footer-columns" aria-label="Footer links">
-					<section className="site-footer-section" aria-label="Company links">
-						<h3>Company</h3>
-						<ul>
-							<li><a href="/about">About</a></li>
-						</ul>
-					</section>
+			<nav className="site-footer-columns" aria-label="Footer links">
+				<section className="site-footer-section" aria-label="Company links">
+					<h3>Company</h3>
+					<ul>
+						<li><a href="/about">About</a></li>
+					</ul>
+				</section>
 
-					<section className="site-footer-section" aria-label="Product links">
-						<h3>Features</h3>
-						<ul>
-							<li><a href="/features/design-system">Design System</a></li>
-						</ul>
-					</section>
+				<section className="site-footer-section" aria-label="Product links">
+					<h3>Features</h3>
+					<ul>
+						<li><a href="/features/design-system">Design System</a></li>
+					</ul>
+				</section>
 
-					<section className="site-footer-section" aria-label="Resources links">
-						<h3>Techstack</h3>
-						<ul>
-							<li><a href="/techstack/nextjs">NextJS</a></li>
-						</ul>
-					</section>
+				<section className="site-footer-section" aria-label="Resources links">
+					<h3>Techstack</h3>
+					<ul>
+						<li><a href="/techstack/nextjs">NextJS</a></li>
+					</ul>
+				</section>
 
-					<section className="site-footer-section" aria-label="Legal links">
-						<h3>Download</h3>
-						<ul>
-							<li>
-								<a href="https://github.com/goldlabelapps/nx" target="_blank" rel="noopener noreferrer">
-									GitHub
-								</a>
-							</li>
-						</ul>
-					</section>
-				</nav>
-			</div>
+				<section className="site-footer-section" aria-label="Legal links">
+					<h3>Download</h3>
+					<ul>
+						<li>
+							<a href="https://github.com/goldlabelapps/nx" target="_blank" rel="noopener noreferrer">
+								GitHub
+							</a>
+						</li>
+					</ul>
+				</section>
+			</nav>
 		</footer>
 	);
 }

--- a/apps/nx/app/components/SiteHeader.tsx
+++ b/apps/nx/app/components/SiteHeader.tsx
@@ -23,9 +23,9 @@ export default function SiteHeader({
 	return (
 		<header className="site-header">
 			<div className="site-header-top" aria-label="Main header bar">
-				<div className="site-footer-brand" aria-label="Brand and overview">
+				<div className="site-brand" aria-label="Brand and overview">
 					<div className="site-header-title-row">
-						<a className="site-home-reset" href={homeHref} aria-label="Home">
+						<a className="site-home-link" href={homeHref} aria-label="Home">
 							<img src={logoSrc} alt={logoAlt} aria-hidden={true} />
 						</a>
 						<div className="site-header-text-stack">
@@ -52,7 +52,7 @@ export default function SiteHeader({
 					</div>
 				</div>
 
-				<details className="site-header-mobile-nav site-floating-nav" aria-label="Mobile navigation">
+				<details className="site-header-mobile-nav" aria-label="Mobile navigation">
 					<summary className="site-mobile-nav-trigger">Menu</summary>
 					<nav className="site-mobile-nav-panel" aria-label="Primary navigation">
 						{navItems}

--- a/apps/nx/app/components/SiteMain.tsx
+++ b/apps/nx/app/components/SiteMain.tsx
@@ -20,13 +20,11 @@ export default function SiteMain({
 	return (
 		<section className="site-col site-col-center" aria-label="Page content">
 			<div className="site-panel site-panel-main">
-				
-                {featuredImage ? (
-                    <div className="site-featured-image" aria-label="Featured image" aria-hidden="true">
-                        <img className="site-featured-image-bg" src={featuredImage} alt="" />
-                    </div>
-                ) : null}
-
+				{featuredImage ? (
+					<div className="site-featured-image" aria-label="Featured image" aria-hidden="true">
+						<img className="site-featured-image-bg" src={featuredImage} alt="" />
+					</div>
+				) : null}
 
 				<RenderMarkdown config={config}>{content}</RenderMarkdown>
 			</div>

--- a/apps/nx/app/layout.tsx
+++ b/apps/nx/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import '@nx/design-system';
+import '@nx/design-system/styles.css';
+import '@nx/design-system/site-layout.css';
 import fs from 'fs';
 import path from 'path';
 import { AppShell, DesignSystemProvider } from '@nx/design-system';
@@ -66,7 +67,7 @@ export default async function RootLayout({
       </head>
       <body>
         <div className="wrapper">
-          <DesignSystemProvider mode="light">
+          <DesignSystemProvider mode="dark">
             <UbereduxProvider config={config}>
               <AppShell>{children}</AppShell>
             </UbereduxProvider>

--- a/apps/nx/app/site-layout.css
+++ b/apps/nx/app/site-layout.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light;
+}
+
+.site-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  gap: 1.25rem;
+  padding: 1.25rem clamp(1rem, 2.5vw, 2rem) 2rem;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  color: #0f172a;
+}
+
+.site-header,
+.site-footer,
+.site-panel {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  backdrop-filter: blur(10px);
+}
+
+.site-header {
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.site-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.site-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.site-header-title-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.site-home-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #f8fafc;
+}
+
+.site-home-link img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.site-header-text-stack {
+  min-width: 0;
+}
+
+.site-header-text-stack h1 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
+  line-height: 1.2;
+}
+
+.site-breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #475569;
+  font-size: 0.92rem;
+}
+
+.site-breadcrumbs li + li::before {
+  content: "/";
+  margin-right: 0.45rem;
+  color: #94a3b8;
+}
+
+.site-breadcrumbs a,
+.site-nav-item > a,
+.site-nav-branch-summary a,
+.site-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-breadcrumbs a:hover,
+.site-nav-item > a:hover,
+.site-nav-branch-summary a:hover,
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+.site-header-mobile-nav {
+  display: none;
+}
+
+.site-mobile-nav-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  background: #0f172a;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.site-mobile-nav-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  background: #f8fafc;
+}
+
+.site-main {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr) minmax(220px, 280px);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.site-col {
+  min-width: 0;
+}
+
+.site-panel {
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+}
+
+.site-nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-nav-item > a,
+.site-nav-branch-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.8rem;
+  border-radius: 0.75rem;
+  color: #0f172a;
+  transition: background-color 160ms ease, transform 160ms ease;
+}
+
+.site-nav-item > a:hover,
+.site-nav-branch-summary:hover {
+  background: #f1f5f9;
+  transform: translateY(-1px);
+}
+
+.site-nav-branch summary {
+  list-style: none;
+}
+
+.site-nav-branch summary::-webkit-details-marker {
+  display: none;
+}
+
+.site-nav-branch-toggle {
+  color: #64748b;
+  font-weight: 700;
+}
+
+.site-featured-image {
+  margin-bottom: 1rem;
+  overflow: hidden;
+  border-radius: 0.95rem;
+  background: #f8fafc;
+}
+
+.site-featured-image-bg {
+  display: block;
+  width: 100%;
+  max-height: 320px;
+  object-fit: cover;
+}
+
+.site-sidebar-placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.site-sidebar-placeholder-label {
+  margin: 0;
+  font-weight: 700;
+}
+
+.site-sidebar-placeholder-text {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.site-footer {
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+}
+
+.site-footer-columns {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.site-footer-section {
+  min-width: 0;
+}
+
+.site-footer-section h3 {
+  margin: 0 0 0.6rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.site-footer-section ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+@media (max-width: 1100px) {
+  .site-main {
+    grid-template-columns: 1fr;
+  }
+
+  .site-col-left,
+  .site-col-right {
+    order: 2;
+  }
+
+  .site-col-center {
+    order: 1;
+  }
+}
+
+@media (max-width: 760px) {
+  .site-shell {
+    padding: 0.9rem 0.9rem 1.25rem;
+  }
+
+  .site-header-top {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .site-header-mobile-nav {
+    display: block;
+  }
+
+  .site-footer-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header {
+    padding: 0.9rem;
+  }
+
+  .site-footer-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .site-header-title-row {
+    align-items: flex-start;
+  }
+
+  .site-home-link {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+}

--- a/apps/nx/public/nx/markdown/index.md
+++ b/apps/nx/public/nx/markdown/index.md
@@ -1,8 +1,8 @@
 ---
 order: 1 
 slug: /
-title: Fast to build
-tags: NX°, free, framework, fullstack, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, SSG, Server Side JavaScript, Node, NextJS
+title: NX°
+tags: free, framework, fullstack, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, SSG, Server Side JavaScript, Node, NextJS
 icon: rocket
 image: https://live.staticflickr.com/65535/55043297044_45e9c515ae_b.jpg
 ---

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "dev": "concurrently -n nx,admin,storybook -c blue,green,magenta \"pnpm --dir apps/nx dev\" \"pnpm --dir apps/admin dev\" \"pnpm --dir packages/design-system dev\"",
-    "build": "turbo run build",
+    "build": "pnpm --dir apps/nx build",
     "clean": "bash ./shell/clean-repo.sh",
     "lint": "turbo run lint",
     "test": "echo 'Tests are disabled'",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -17,11 +17,16 @@
       "import": "./dist/styles/globals.css",
       "require": "./dist/styles/globals.css",
       "default": "./dist/styles/globals.css"
+    },
+    "./site-layout.css": {
+      "import": "./dist/styles/site-layout.css",
+      "require": "./dist/styles/site-layout.css",
+      "default": "./dist/styles/site-layout.css"
     }
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && mkdir -p dist/styles && cp src/styles/globals.css dist/styles/globals.css",
+    "build": "tsc -p tsconfig.build.json && mkdir -p dist/styles && cp src/styles/*.css dist/styles/",
     "type-check": "tsc --noEmit",
     "lint": "echo 'No lint configured yet'",
     "clean": "rm -rf dist",

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,10 +1,8 @@
+import './styles/globals.css';
+
 export { DesignSystemProvider } from './components/DesignSystemProvider';
 export { AppShell, PageSection, SectionTitle } from './components/Primitives';
 export { Eyebrow } from './components/Eyebrow';
 export { BrandMark } from './components/BrandMark';
 export { Alert, Card, Field } from './components/FormControls';
 export { createAppTheme, type DesignSystemMode } from './theme';
-
-// The stylesheet is imported explicitly by consumers through the package CSS entry.
-// Allow CJS consumers to require the package (bundlers will use ESM by default)
-// No runtime code needed; exports above are the public surface.

--- a/packages/design-system/src/styles/site-layout.css
+++ b/packages/design-system/src/styles/site-layout.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light;
+}
+
+.site-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  gap: 1.25rem;
+  padding: 1.25rem clamp(1rem, 2.5vw, 2rem) 2rem;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  color: #0f172a;
+}
+
+.site-header,
+.site-footer,
+.site-panel {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  backdrop-filter: blur(10px);
+}
+
+.site-header {
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.site-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.site-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.site-header-title-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.site-home-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+  border-radius: 999px;
+  overflow: hidden;
+  background: #f8fafc;
+}
+
+.site-home-link img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.site-header-text-stack {
+  min-width: 0;
+}
+
+.site-header-text-stack h1 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
+  line-height: 1.2;
+}
+
+.site-breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #475569;
+  font-size: 0.92rem;
+}
+
+.site-breadcrumbs li + li::before {
+  content: "/";
+  margin-right: 0.45rem;
+  color: #94a3b8;
+}
+
+.site-breadcrumbs a,
+.site-nav-item > a,
+.site-nav-branch-summary a,
+.site-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-breadcrumbs a:hover,
+.site-nav-item > a:hover,
+.site-nav-branch-summary a:hover,
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+.site-header-mobile-nav {
+  display: none;
+}
+
+.site-mobile-nav-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  background: #0f172a;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.site-mobile-nav-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  background: #f8fafc;
+}
+
+.site-main {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr) minmax(220px, 280px);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.site-col {
+  min-width: 0;
+}
+
+.site-panel {
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+}
+
+.site-nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-nav-item > a,
+.site-nav-branch-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.8rem;
+  border-radius: 0.75rem;
+  color: #0f172a;
+  transition: background-color 160ms ease, transform 160ms ease;
+}
+
+.site-nav-item > a:hover,
+.site-nav-branch-summary:hover {
+  background: #f1f5f9;
+  transform: translateY(-1px);
+}
+
+.site-nav-branch summary {
+  list-style: none;
+}
+
+.site-nav-branch summary::-webkit-details-marker {
+  display: none;
+}
+
+.site-nav-branch-toggle {
+  color: #64748b;
+  font-weight: 700;
+}
+
+.site-featured-image {
+  margin-bottom: 1rem;
+  overflow: hidden;
+  border-radius: 0.95rem;
+  background: #f8fafc;
+}
+
+.site-featured-image-bg {
+  display: block;
+  width: 100%;
+  max-height: 320px;
+  object-fit: cover;
+}
+
+.site-sidebar-placeholder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.site-sidebar-placeholder-label {
+  margin: 0;
+  font-weight: 700;
+}
+
+.site-sidebar-placeholder-text {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.site-footer {
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+}
+
+.site-footer-columns {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.site-footer-section {
+  min-width: 0;
+}
+
+.site-footer-section h3 {
+  margin: 0 0 0.6rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.site-footer-section ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+@media (max-width: 1100px) {
+  .site-main {
+    grid-template-columns: 1fr;
+  }
+
+  .site-col-left,
+  .site-col-right {
+    order: 2;
+  }
+
+  .site-col-center {
+    order: 1;
+  }
+}
+
+@media (max-width: 760px) {
+  .site-shell {
+    padding: 0.9rem 0.9rem 1.25rem;
+  }
+
+  .site-header-top {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .site-header-mobile-nav {
+    display: block;
+  }
+
+  .site-footer-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header {
+    padding: 0.9rem;
+  }
+
+  .site-footer-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .site-header-title-row {
+    align-items: flex-start;
+  }
+
+  .site-home-link {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+}

--- a/tests/unit/design-system-package.test.ts
+++ b/tests/unit/design-system-package.test.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('design-system package entry', () => {
+  it('loads the shared stylesheet from the app layout', () => {
+    const layoutPath = path.join(process.cwd(), 'apps', 'nx', 'app', 'layout.tsx');
+    const layoutSource = fs.readFileSync(layoutPath, 'utf8');
+
+    expect(layoutSource).toContain("import '@nx/design-system/styles.css';");
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,9 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "build/**"]
+      "outputs": ["dist/**", ".next/**", "build/**"],
+      "dependsOn": ["^build"],
+      "outputLogs": "full"
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
Extracts site layout styles into a dedicated `site-layout.css` shared between the app and the design-system package. Restores previously commented-out SiteSidebar and SiteFooter components, cleans up SiteFooter markup by removing the wrapper div, fixes CSS class names in SiteHeader (site-brand, site-home-link), switches default theme mode to dark, updates the design-system build script to copy all CSS files, and adds a package export for the new stylesheet. Also adds a unit test verifying the stylesheet import and updates the homepage title.