### PR TITLE
Build design-system before www app

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.12.4",
   "scripts": {
     "dev": "next dev -p 1999 --webpack",
+    "prebuild": "pnpm --dir ../../packages/design-system build",
     "build": "next build --webpack",
     "start": "next start",
     "test": "jest --runInBand --passWithNoTests",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "dev": "concurrently -n nx,admin,storybook -c blue,green,magenta \"pnpm --dir apps/www dev\" \"pnpm --dir apps/admin dev\" \"pnpm --dir packages/design-system dev\"",
-    "build": "pnpm --dir apps/www build",
+    "build": "pnpm --dir packages/design-system build && pnpm --dir apps/www build",
     "clean": "bash ./shell/clean-repo.sh",
     "lint": "turbo run lint",
     "test": "echo 'Tests are disabled'",


### PR DESCRIPTION
Ensures the design-system package is built prior to the www app in both the root build script and as a prebuild step in the www package.