### PR TITLE
Add Vercel config and bump admin to v2.1.0

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "packageManager": "pnpm@11.13.0",
   "scripts": {
     "dev": "next dev -p 2000 --webpack",

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm --version && corepack pnpm install --frozen-lockfile",
+  "buildCommand": "corepack pnpm build"
+}

--- a/packages/design-system/vercel.json
+++ b/packages/design-system/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": null,
+  "installCommand": "corepack enable && corepack prepare pnpm@8.15.9 --activate && corepack pnpm install --no-frozen-lockfile",
+  "buildCommand": "pnpm build-storybook",
+  "outputDirectory": "storybook-static"
+}


### PR DESCRIPTION
Adds vercel.json for the admin app with explicit pnpm corepack setup for install/build commands. Bumps version to 2.1.0.