### PR TITLE
Move page description above featured image

### DIFF
--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -169,6 +169,13 @@ export default async function Page({ params }: T_PageProps) {
                     </DesktopOnly>
 
                     <DesignSystemSiteMain>
+
+                        {pageDescription ? (
+                            <Heading variant="h2" style={{ marginBottom: '1rem' }} tone="secondary">
+                                {pageDescription}
+                            </Heading>
+                        ) : null}
+
                         
                         {featuredImageSrc ? (
                             <FeaturedImage
@@ -179,15 +186,8 @@ export default async function Page({ params }: T_PageProps) {
                             />
                         ) : null}
                         
-
-                        {pageDescription ? (
-                            <Heading variant="h2" style={{ marginTop: '1rem' }} tone="secondary">
-                                {pageDescription}
-                            </Heading>
-                        ) : null}
-
                         {breadcrumbItems.length ? (
-                            <div style={{ marginTop: '1rem', marginBottom: '0.5rem' }}>
+                            <div style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>
                                 <Breadcrumb items={breadcrumbItems} />
                             </div>
                         ) : null}


### PR DESCRIPTION
Reorders the page layout so the description heading appears before the featured image instead of after it. Also adjusts spacing: removes top margin from the heading (now uses bottom margin) and increases breadcrumb top margin from 1rem to 1.5rem.