### PR TITLE
Replace SiteNav anchors with MUI buttons

### DIFF
--- a/apps/www/app/NX/DesignSystem/RoutedSiteNav.tsx
+++ b/apps/www/app/NX/DesignSystem/RoutedSiteNav.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { SiteNav, type T_NavNode } from '@nx/design-system';
+import { useRouter } from 'next/navigation';
+
+type RoutedSiteNavProps = {
+  items: T_NavNode[];
+};
+
+export default function RoutedSiteNav({ items }: RoutedSiteNavProps) {
+  const router = useRouter();
+
+  function handleNavigate(route: string) {
+    if (!route || route === '#') {
+      return;
+    }
+
+    router.push(route);
+  }
+
+  return <SiteNav items={items} navigateTo={handleNavigate} />;
+}

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -9,13 +9,14 @@ import {
     FeaturedImage,
     Heading,
     SiteFooter,
-    SiteHeader,
+    Header,
     SiteMain as DesignSystemSiteMain,
     SiteNav,
     type T_NavNode,
 } from '@nx/design-system';
 import nxConfig from '../../nx.config.json';
 import HeaderActions from '../NX/DesignSystem/HeaderActions';
+import RoutedSiteNav from '../NX/DesignSystem/RoutedSiteNav';
 import { ThemeModeProvider } from '../NX/DesignSystem/ThemeModeContext';
 import {
     serverUseMDBySlug,
@@ -152,19 +153,19 @@ export default async function Page({ params }: T_PageProps) {
         <ThemeModeProvider initialMode={themeMode} themeConfigs={themeConfigs}>
             <div className="site-shell">
                 
-                <SiteHeader
+                <Header
                     title={data.title || title}
                     description={slugArr.length ? '' : (config?.description || '')}
                     homeHref="/"
                     logoSrc="/nx/png/favicon.png"
-                    navItems={<SiteNav items={navItems} />}
-                    actions={<HeaderActions navItems={<SiteNav items={navItems} />} />}
+                    navItems={<RoutedSiteNav items={navItems} />}
+                    actions={<HeaderActions navItems={<RoutedSiteNav items={navItems} />} />}
                 />
 
                 <main className="site-main" id="main">
                     <DesktopOnly>
                         <aside className="site-col site-col-left" aria-label="NX°  Navigation">
-                            <SiteNav items={navItems} />
+                            <RoutedSiteNav items={navItems} />
                         </aside>
                     </DesktopOnly>
 

--- a/apps/www/tests/unit/design-system/routed-site-nav.test.tsx
+++ b/apps/www/tests/unit/design-system/routed-site-nav.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RoutedSiteNav from '../../../app/NX/DesignSystem/RoutedSiteNav';
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push,
+  }),
+}));
+
+describe('RoutedSiteNav', () => {
+  beforeEach(() => {
+    push.mockClear();
+  });
+
+  it('pushes the clicked route through the Next router', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RoutedSiteNav
+        items={[
+          { title: 'Home', slug: '/' },
+          { title: 'Features', path: '/features' },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText('Features'));
+
+    expect(push).toHaveBeenCalledWith('/features');
+  });
+});

--- a/apps/www/tests/unit/design-system/site-components.test.tsx
+++ b/apps/www/tests/unit/design-system/site-components.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import {
   SiteFooter,
-  SiteHeader,
+  Header,
   SiteMain,
   SiteNav,
   type T_NavNode,
@@ -25,15 +25,16 @@ describe('design-system site components', () => {
     expect(screen.getByText('Design System')).toBeInTheDocument();
   });
 
-  it('renders breadcrumbs and mobile navigation in the header', () => {
+  it('renders the header home link and actions', () => {
     render(
-      <SiteHeader
+      <Header
         title="Docs"
         description="Reference"
         homeHref="/"
         logoSrc="/nx/png/favicon.png"
         logoAlt="NX logo"
         navItems={<SiteNav items={[{ title: 'Home', slug: '/' }]} />}
+        actions={<button type="button">Toggle menu</button>}
       />,
     );
 

--- a/packages/design-system/src/components/layout/Main.tsx
+++ b/packages/design-system/src/components/layout/Main.tsx
@@ -2,7 +2,7 @@ import type { SiteMainProps } from '../../types';
 
 export default function Main({ children, featuredImage }: SiteMainProps) {
   return (
-    <section aria-label="Page content">
+    <section aria-label="Page content" className="site-main-content">
       {featuredImage ? (
         <div aria-label="Featured image" aria-hidden="true">
           <img src={featuredImage} alt="" />

--- a/packages/design-system/src/components/navigation/SiteNav.tsx
+++ b/packages/design-system/src/components/navigation/SiteNav.tsx
@@ -1,7 +1,13 @@
-import type { ReactNode } from 'react';
-import type { SiteNavProps, T_NavNode } from '../../types';
+'use client';
 
-function getNavHref(item: T_NavNode): string {
+import { Fragment, type ReactNode } from 'react';
+import type { SiteNavProps, T_NavNode } from '../../types';
+import List from '../lists/List';
+import ListItem from '../lists/ListItem';
+import ListItemButton from '../lists/ListItemButton';
+import ListItemText from '../lists/ListItemText';
+
+function getNavPath(item: T_NavNode): string {
   if (typeof item.slug === 'string' && item.slug.trim()) {
     return item.slug;
   }
@@ -11,37 +17,71 @@ function getNavHref(item: T_NavNode): string {
   return '#';
 }
 
-function renderNavItems(items: T_NavNode[], keyPrefix = 'nav'): ReactNode {
+function isSuppressedHomeItem(item: T_NavNode, depth: number): boolean {
+  if (depth !== 0) {
+    return false;
+  }
+
+  const title = (item.title ?? '').trim().toLowerCase();
+  const path = getNavPath(item);
+  return title === 'home' || path === '/';
+}
+
+
+function renderNavItems(
+  items: T_NavNode[],
+  navigateTo?: (path: string, item: T_NavNode) => void,
+  depth = 0,
+  keyPrefix = 'nav'
+): ReactNode {
   if (!Array.isArray(items) || !items.length) {
     return null;
   }
 
   return (
-    <ul>
+    <List disablePadding dense>
       {items.map((item, index) => {
+        if (isSuppressedHomeItem(item, depth)) {
+          return null;
+        }
+
         const key = `${keyPrefix}-${index}-${item.title || item.slug || item.path || 'node'}`;
         const hasChildren = Array.isArray(item.children) && item.children.length > 0;
         const label = item.title || 'Untitled';
 
         return (
-          <li key={key}>
-            {hasChildren ? (
-              <details>
-                <summary>
-                  <a href={getNavHref(item)}>{label}</a>
-                </summary>
-                {renderNavItems(item.children as T_NavNode[], key)}
-              </details>
-            ) : (
-              <a href={getNavHref(item)}>{label}</a>
-            )}
-          </li>
+          <Fragment key={key}>
+            <ListItem disablePadding>
+              <ListItemButton
+                onClick={() => {
+                  navigateTo?.(getNavPath(item), item);
+                }}
+                sx={{
+                  pl: 1.5 + depth * 2,
+                  py: 0.25,
+                  minHeight: 28,
+                  borderRadius: 1,
+                }}
+              >
+                <ListItemText
+                  primary={label}
+                  sx={{ my: 0 }}
+                  primaryTypographyProps={{
+                    fontWeight: hasChildren ? 600 : 500,
+                    fontSize: '1rem',
+                    lineHeight: 1.15,
+                  }}
+                />
+              </ListItemButton>
+            </ListItem>
+            {hasChildren ? renderNavItems(item.children as T_NavNode[], navigateTo, depth + 1, key) : null}
+          </Fragment>
         );
       })}
-    </ul>
+    </List>
   );
 }
 
-export default function SiteNav({ items }: SiteNavProps) {
-  return renderNavItems(items);
+export default function SiteNav({ items, navigateTo }: SiteNavProps) {
+  return renderNavItems(items, navigateTo);
 }

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -18,7 +18,7 @@ export { default as SiteNav } from './components/navigation/SiteNav';
 export { default as FeaturedImage } from './components/images/FeaturedImage';
 export type { T_NavNode } from './types';
 export { default as SiteFooter } from './components/layout/Footer';
-export { default as SiteHeader } from './components/layout/Header';
+export { default as Header } from './components/layout/Header';
 export { default as MenuDrawer } from './components/layout/MenuDrawer';
 export { default as SiteMain } from './components/layout/Main';
 export { default as Icon } from './components/icons/Icon';

--- a/packages/design-system/src/stories/layout/Header.stories.tsx
+++ b/packages/design-system/src/stories/layout/Header.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { SiteHeader, SiteNav, type T_NavNode } from '../../index';
+import { Header, SiteNav, type T_NavNode } from '../../index';
 
 const sampleNav: T_NavNode[] = [
   { title: 'Home', slug: '/' },
@@ -14,18 +14,18 @@ const sampleNav: T_NavNode[] = [
   { title: 'Docs', slug: '/docs' },
 ];
 
-const meta: Meta<typeof SiteHeader> = {
+const meta: Meta<typeof Header> = {
   title: 'Layout/Header',
-  component: SiteHeader,
+  component: Header,
 };
 
 export default meta;
-type Story = StoryObj<typeof SiteHeader>;
+type Story = StoryObj<typeof Header>;
 
 export const Description: Story = {
   render: () => (
     <div className="site-shell">
-      <SiteHeader
+      <Header
         title="NX Documentation"
         description="Design system reference and implementation guides"
         homeHref="/"

--- a/packages/design-system/src/styles/globals.css
+++ b/packages/design-system/src/styles/globals.css
@@ -104,3 +104,7 @@ li::marker {
 .site-panel-main li {
 	position: relative;
 }
+
+.site-main-content p {
+  font-size: 1.25em;
+}

--- a/packages/design-system/src/styles/site-layout.css
+++ b/packages/design-system/src/styles/site-layout.css
@@ -234,7 +234,7 @@
 .site-footer {
   background: var(--surface-footer);
   border-radius: 3px;
-  margin-top: clamp(5rem, 32svh, 10rem);
+  margin-top: max(100svh, clamp(5rem, 32svh, 10rem));
   padding: 1.1rem 1.25rem 0.75rem;
 }
 
@@ -290,7 +290,7 @@
   }
 
   .site-footer {
-    margin-top: clamp(8rem, 40svh, 14rem);
+    margin-top: max(100svh, clamp(8rem, 40svh, 14rem));
   }
 
   .site-header-top {

--- a/packages/design-system/src/types.d.ts
+++ b/packages/design-system/src/types.d.ts
@@ -138,6 +138,7 @@ export type T_NavNode = {
 
 export type SiteNavProps = {
 	items: T_NavNode[];
+	navigateTo?: (path: string, item: T_NavNode) => void;
 };
 
 export type UseIsMobileOptions = {

--- a/packages/design-system/tests/components/brand/brand.test.tsx
+++ b/packages/design-system/tests/components/brand/brand.test.tsx
@@ -20,9 +20,10 @@ describe('brand components', () => {
   });
 
   it('uses custom face and smile colors when provided', () => {
-    render(<Logo faceColor="#123456" smileColor="#abcdef" />);
+    const { container } = render(<Logo faceColor="#123456" smileColor="#abcdef" />);
 
-    const paths = document.querySelectorAll('svg[aria-label="NX Favicon"] path');
+    const favicon = container.querySelector('svg[aria-label="NX Favicon"]');
+    const paths = favicon?.querySelectorAll('path');
     expect(paths[0]?.getAttribute('fill')).toBe('#123456');
     expect(paths[1]?.getAttribute('fill')).toBe('#abcdef');
   });

--- a/packages/design-system/tests/components/navigation/navigation.test.tsx
+++ b/packages/design-system/tests/components/navigation/navigation.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import Breadcrumb from '../../../src/components/navigation/Breadcrumb';
 import SiteNav from '../../../src/components/navigation/SiteNav';
 
@@ -21,7 +21,7 @@ describe('site navigation', () => {
   });
 
   it('renders flat and nested items', () => {
-    const { container } = render(
+    render(
       <SiteNav
         items={[
           { title: 'Home', slug: '/' },
@@ -37,9 +37,28 @@ describe('site navigation', () => {
       />
     );
 
-    expect(container.querySelector('a[href="/"]')?.textContent).toBe('Home');
-    expect(container.querySelector('a[href="/features"]')?.textContent).toBe('Features');
-    expect(container.querySelector('a[href="/features/design-system"]')?.textContent).toBe('Design System');
-    expect(container.querySelector('a[href="/features/storybook"]')?.textContent).toBe('Storybook');
+    expect(screen.queryByRole('button', { name: 'Home' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Features' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Design System' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Storybook' })).toBeTruthy();
+  });
+
+  it('calls navigateTo with path and item when clicked', () => {
+    const navigateTo = vi.fn();
+
+    const { container } = render(
+      <SiteNav
+        navigateTo={navigateTo}
+        items={[
+          { title: 'Home', slug: '/' },
+          { title: 'Docs', path: '/docs' },
+        ]}
+      />
+    );
+
+    expect(within(container).queryByRole('button', { name: 'Home' })).toBeNull();
+
+    fireEvent.click(within(container).getByRole('button', { name: 'Docs' }));
+    expect(navigateTo).toHaveBeenCalledWith('/docs', { title: 'Docs', path: '/docs' });
   });
 });


### PR DESCRIPTION
Refactors SiteNav to render MUI List/ListItemButton elements instead of plain anchor tags, accepting an optional `navigateTo` callback for programmatic routing. Adds a `RoutedSiteNav` wrapper for Next.js apps that wires `useRouter.push` to the callback. Renames the `SiteHeader` export to `Header` throughout.