### PR TITLE
Use metadata manifest in root layout

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -47,6 +47,7 @@ export const metadata: Metadata = {
   metadataBase,
   title: `${title}, ${description}`,
   description,
+  manifest: '/manifest.webmanifest',
   icons: {
     icon: favicon,
     shortcut: favicon,
@@ -63,7 +64,6 @@ export default async function RootLayout({
     <html lang="en" data-design-system={designSystemId}>
       <head>
         <link rel="icon" href={favicon} />
-        <link rel="manifest" href={`/${resolvedTenant}/manifest.webmanifest`} />
         <meta name="application-name" content={title} />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />


### PR DESCRIPTION
Switch manifest registration to Next.js metadata by adding `manifest: '/manifest.webmanifest'` and removing the manual `<link rel="manifest">` from `<head>`. This avoids tenant-specific manifest paths and keeps head tags managed consistently through the metadata API.