### PR TITLE
Enhance theme mode support and refine branding components

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,8 @@
             height="32"
         />
         </a>
-        <span>NX° </span>
+        <span>NX° Open Source</span>
     </h1>
 </div>
 
 > NX° is a JavaScript platform for creating apps across a network of projects and needs. Built for creators, coders, collaborators, and audiences who need a flexible space to publish, discover, and engage with rich content [more...](./docs/README.md)
-
-## Docs
-
-- [Overview](./docs/README.md)
-- [Tech Stack](./docs/techstack.md)
-- [Apps and Packages](./docs/apps-packages.md)
-
-## Storybook
-
-- Start Storybook from the workspace root with `pnpm storybook`.
-- Build the static Storybook bundle from the workspace root with `pnpm build-storybook`.
-- The implementation lives in `packages/design-system`, and the root scripts forward there.

--- a/apps/www/app/Init.tsx
+++ b/apps/www/app/Init.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { setUbereduxKey, useDispatch } from '@nx/uberedux';
+
+export default function Init() {
+  const dispatch = useDispatch();
+  const hasInitialized = useRef(false);
+
+  useEffect(() => {
+    if (hasInitialized.current) return;
+
+    hasInitialized.current = true;
+
+    dispatch(
+      setUbereduxKey({
+        key: 'init',
+        value: {
+          mountedAt: new Date().toISOString(),
+          path: typeof window !== 'undefined' ? window.location.pathname : '/',
+        },
+      }),
+    );
+  }, [dispatch]);
+
+  return null;
+}

--- a/apps/www/app/NX/DesignSystem/ThemeModeContext.tsx
+++ b/apps/www/app/NX/DesignSystem/ThemeModeContext.tsx
@@ -4,6 +4,7 @@ import { DesignSystemProvider, type DesignSystemThemeConfig } from '@nx/design-s
 import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
 
 export type ThemeMode = 'light' | 'dark';
+export type ThemeModePreference = ThemeMode | 'system';
 
 export type ThemeModeContextValue = {
   mode: ThemeMode;
@@ -12,7 +13,7 @@ export type ThemeModeContextValue = {
 
 type ThemeModeProviderProps = {
   children: ReactNode;
-  initialMode: ThemeMode;
+  initialMode: ThemeModePreference;
   themeConfigs?: Partial<Record<ThemeMode, DesignSystemThemeConfig>>;
 };
 
@@ -28,8 +29,20 @@ export function useThemeMode() {
   return context;
 }
 
+export function resolveThemeMode(initialMode: ThemeModePreference | undefined): ThemeMode {
+  if (initialMode === 'dark' || initialMode === 'light') {
+    return initialMode;
+  }
+
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  return 'light';
+}
+
 export function ThemeModeProvider({ children, initialMode, themeConfigs }: ThemeModeProviderProps) {
-  const [mode, setMode] = useState<ThemeMode>(initialMode);
+  const [mode, setMode] = useState<ThemeMode>(() => resolveThemeMode(initialMode));
   const value = useMemo(() => ({ mode, setMode }), [mode]);
   const activeThemeConfig = themeConfigs?.[mode];
 

--- a/apps/www/app/NX/DesignSystem/UbereduxStatePreview.tsx
+++ b/apps/www/app/NX/DesignSystem/UbereduxStatePreview.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useSlice } from '@nx/uberedux';
+
+export default function UbereduxStatePreview() {
+  const state = useSlice();
+
+  return (
+    <pre
+      style={{
+        margin: 0,
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        fontSize: '0.8rem',
+        lineHeight: 1.4,
+        overflowX: 'auto',
+      }}
+    >
+      {JSON.stringify(state, null, 2)}
+    </pre>
+  );
+}

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -198,6 +198,7 @@ export default async function Page({ params }: T_PageProps) {
 
                         <RenderMarkdown config={config}>{content}</RenderMarkdown>
                     </DesignSystemSiteMain>
+                    
                     <aside aria-label="NX° Aside" style={{ marginTop: 50 }}>
                         <Card>
                             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -18,6 +18,7 @@ import nxConfig from '../../nx.config.json';
 import HeaderActions from '../NX/DesignSystem/HeaderActions';
 import RoutedSiteNav from '../NX/DesignSystem/RoutedSiteNav';
 import { ThemeModeProvider } from '../NX/DesignSystem/ThemeModeContext';
+import UbereduxStatePreview from '../NX/DesignSystem/UbereduxStatePreview';
 import {
     serverUseMDBySlug,
     serverUseAllMd,
@@ -98,6 +99,7 @@ export default async function Page({ params }: T_PageProps) {
     const featuredImageSrc = typeof data.image === 'string' && data.image.trim()
         ? data.image
         : config.images?.light || '';
+    const headerIconSrc = featuredImageSrc || config.images?.light || '/nx/png/favicon.png';
     const navItems = (await serverUseNav()) as T_NavNode[];
     const breadcrumbItems = slugArr.length
         ? [
@@ -159,7 +161,7 @@ export default async function Page({ params }: T_PageProps) {
                     title={data.title || title}
                     description={slugArr.length ? '' : (config?.description || '')}
                     homeHref="/"
-                    logoSrc="/nx/png/favicon.png"
+                    logoSrc={headerIconSrc}
                     navItems={<RoutedSiteNav items={navItems} />}
                     actions={<HeaderActions navItems={<RoutedSiteNav items={navItems} />} />}
                 />
@@ -202,9 +204,11 @@ export default async function Page({ params }: T_PageProps) {
                     </DesignSystemSiteMain>
                     <aside aria-label="NX° Aside" style={{ marginTop: 50 }}>
                         <Card>
-                            Uberedux
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                                <>Uberedux</>
+                                <UbereduxStatePreview />
+                            </div>
                         </Card>
-                        
                     </aside>
                 </main>
                 

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import fs from "fs";
 import matter from "gray-matter";
 import { notFound } from "next/navigation";
 import {
+    Card,
     Breadcrumb,
     FeaturedImage,
     Heading,
@@ -124,7 +125,9 @@ export default async function Page({ params }: T_PageProps) {
         textSecondary?: string;
     }> | undefined;
     const selectedTheme = (themes?.[defaultThemeName] ?? themes?.light);
-    const themeMode = selectedTheme?.mode === 'dark' ? 'dark' : 'light';
+    const themeMode = defaultThemeName === 'system'
+        ? 'system'
+        : (selectedTheme?.mode === 'dark' ? 'dark' : 'light');
     const themeConfigs = {
         light: themes?.light
             ? {
@@ -197,9 +200,12 @@ export default async function Page({ params }: T_PageProps) {
 
                         <RenderMarkdown config={config}>{content}</RenderMarkdown>
                     </DesignSystemSiteMain>
-                    {/* <aside aria-label="NX° Aside" style={{ marginTop: 50 }}>
-                        Aside, share
-                    </aside> */}
+                    <aside aria-label="NX° Aside" style={{ marginTop: 50 }}>
+                        <Card>
+                            Uberedux
+                        </Card>
+                        
+                    </aside>
                 </main>
                 
                 <SiteFooter />

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -11,7 +11,6 @@ import {
     SiteFooter,
     Header,
     SiteMain as DesignSystemSiteMain,
-    SiteNav,
     type T_NavNode,
 } from '@nx/design-system';
 import nxConfig from '../../nx.config.json';
@@ -99,7 +98,7 @@ export default async function Page({ params }: T_PageProps) {
     const featuredImageSrc = typeof data.image === 'string' && data.image.trim()
         ? data.image
         : config.images?.light || '';
-    const headerIconSrc = featuredImageSrc || config.images?.light || '/nx/png/favicon.png';
+    const headerIcon = 'home';
     const navItems = (await serverUseNav()) as T_NavNode[];
     const breadcrumbItems = slugArr.length
         ? [
@@ -159,10 +158,7 @@ export default async function Page({ params }: T_PageProps) {
                 
                 <Header
                     title={data.title || title}
-                    description={slugArr.length ? '' : (config?.description || '')}
-                    homeHref="/"
-                    logoSrc={headerIconSrc}
-                    navItems={<RoutedSiteNav items={navItems} />}
+                    icon={data.icon}
                     actions={<HeaderActions navItems={<RoutedSiteNav items={navItems} />} />}
                 />
 

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { AppShell, DesignSystemProvider } from '@nx/design-system';
 import { UbereduxProvider } from '@nx/uberedux';
+import Init from './Init';
 import { normalizeTenant } from './NX/lib/normalizeTenant';
 
 const tenant = normalizeTenant();
@@ -74,6 +75,7 @@ export default async function RootLayout({
         <div className="wrapper">
           <DesignSystemProvider>
             <UbereduxProvider config={config}>
+              <Init />
               <AppShell>{children}</AppShell>
             </UbereduxProvider>
           </DesignSystemProvider>

--- a/apps/www/public/nx/markdown/help/index.md
+++ b/apps/www/public/nx/markdown/help/index.md
@@ -1,9 +1,0 @@
----
-order: 1000
-title: Help
-description: Creating a new NX° App
-slug: /help
-icon: rocket
-tags: help, support, install
-image: https://live.staticflickr.com/65535/55043207718_0af207d889_b.jpg
----

--- a/apps/www/public/nx/markdown/index.md
+++ b/apps/www/public/nx/markdown/index.md
@@ -3,7 +3,7 @@ order: 1
 slug: /
 title: NX°
 tags: free, framework, fullstack, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, SSG, Server Side JavaScript, Node, NextJS
-icon: rocket
+icon: pinpong
 image: https://live.staticflickr.com/65535/55327040507_6ebcd4873b_c.jpg
 ---
 NX° is a high-level framework for rapidly bootstrapping modern apps. Built on modular JavaScript and NextJS, it streamlines fullstack development for both server-side Node and client-side React—so you can launch new web apps fast, without starting from scratch. 
@@ -11,3 +11,4 @@ NX° is a high-level framework for rapidly bootstrapping modern apps. Built on m
 Fast to build, affordable to deploy, and powered by proven web standards—from semantic HTML to static site generation. NX° apps are fast, reliable and make WordPress look very dated
 
 [CleverText text="Ready to create an NX° app?"]
+

--- a/apps/www/public/nx/markdown/index.md
+++ b/apps/www/public/nx/markdown/index.md
@@ -3,7 +3,7 @@ order: 1
 slug: /
 title: NX°
 tags: free, framework, fullstack, JavaScript, Vanilla JavaScript, TypeScript, React, Material UI, Flash, SSG, Server Side JavaScript, Node, NextJS
-icon: pinpong
+icon: pingpong
 image: https://live.staticflickr.com/65535/55327040507_6ebcd4873b_c.jpg
 ---
 NX° is a high-level framework for rapidly bootstrapping modern apps. Built on modular JavaScript and NextJS, it streamlines fullstack development for both server-side Node and client-side React—so you can launch new web apps fast, without starting from scratch. 

--- a/apps/www/public/nx/markdown/techstack/fastapi.md
+++ b/apps/www/public/nx/markdown/techstack/fastapi.md
@@ -7,9 +7,7 @@ tags: Python, FastAPI, tsvector, Postgres
 icon: api
 image: https://live.staticflickr.com/65535/55198277139_08236ed419_b.jpg
 ---
-> [CleverText text="Superfast search with tsvector"]  
-
-[PageLink icon="doc" title="redoc" description="Auto-generated & interactive" url="https://nx-ai.onrender.com/redoc"]  
+> [CleverText text="Superfast search with tsvector"]    
 
 A modern Python backend built with **FastAPI**, providing high performance and easy-to-use APIs. The app is deployed on [Render.com](https://render.com/), ensuring reliable and scalable hosting. 
 

--- a/apps/www/public/nx/markdown/techstack/git.md
+++ b/apps/www/public/nx/markdown/techstack/git.md
@@ -3,7 +3,7 @@ order: 4]550
 title: Git
 description: Proud to share code
 slug: /techstack/git
-icon: blokey
+icon: github
 tags: open source, free, git, github
 image: https://live.staticflickr.com/65535/55153040009_52bba6c7fd_b.jpg
 --- 

--- a/apps/www/tests/unit/themeModeContext.test.tsx
+++ b/apps/www/tests/unit/themeModeContext.test.tsx
@@ -1,0 +1,32 @@
+import { resolveThemeMode } from '../../app/NX/DesignSystem/ThemeModeContext';
+
+describe('resolveThemeMode', () => {
+  const setMatchMedia = (matches: boolean) => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query.includes('dark') ? matches : false,
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  };
+
+  it('uses the browser preference when the configured mode is system', () => {
+    setMatchMedia(true);
+    expect(resolveThemeMode('system')).toBe('dark');
+  });
+
+  it('falls back to light when system preference is unavailable', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: undefined,
+    });
+
+    expect(resolveThemeMode('system')).toBe('light');
+  });
+});

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -1,0 +1,5 @@
+## Storybook
+
+- Start Storybook from the workspace root with `pnpm storybook`.
+- Build the static Storybook bundle from the workspace root with `pnpm build-storybook`.
+- The implementation lives in `packages/design-system`, and the root scripts forward there.

--- a/packages/design-system/src/components/brand/Logo.tsx
+++ b/packages/design-system/src/components/brand/Logo.tsx
@@ -9,6 +9,7 @@ export default function Logo({
   name = 'NX°', 
   children, 
   subtitle, 
+  icon,
   favicon = false, 
   faceColor,
   smileColor,
@@ -43,20 +44,26 @@ export default function Logo({
           lineHeight: 0
         }}
       >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-label="NX Favicon">
-          <g stroke="none" fill="none" fillRule="evenodd">
-            <g>
-              <rect fillOpacity="0" x="0" y="0" width="24" height="24" />
-              <g transform="translate(1, 1)" fillRule="nonzero">
-                <path
-                  d="M11.9316955,0.00778516743 C18.2793961,0.234625 23.2318292,5.339499 22.9916183,11.4103978 C22.7565183,17.4812966 17.4207699,22.2190224 11.0730694,21.9921826 C4.72536881,21.7653428 -0.227064254,16.6604688 0.00803576687,10.58957 C0.248246659,4.51867123 5.58399495,-0.218565786 11.9316955,0.00778516743 Z"
-                  fill={faceFill}
-                />
-                <path d="M8,12 C12.6203742,21.9973959 20,13.9133228 20,13.9133228 C14.7209979,15.4126605 8,12 8,12 Z" fill={smileFill} />
+        {icon ? (
+          <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+            {icon}
+          </Box>
+        ) : (
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-label="NX Favicon">
+            <g stroke="none" fill="none" fillRule="evenodd">
+              <g>
+                <rect fillOpacity="0" x="0" y="0" width="24" height="24" />
+                <g transform="translate(1, 1)" fillRule="nonzero">
+                  <path
+                    d="M11.9316955,0.00778516743 C18.2793961,0.234625 23.2318292,5.339499 22.9916183,11.4103978 C22.7565183,17.4812966 17.4207699,22.2190224 11.0730694,21.9921826 C4.72536881,21.7653428 -0.227064254,16.6604688 0.00803576687,10.58957 C0.248246659,4.51867123 5.58399495,-0.218565786 11.9316955,0.00778516743 Z"
+                    fill={faceFill}
+                  />
+                  <path d="M8,12 C12.6203742,21.9973959 20,13.9133228 20,13.9133228 C14.7209979,15.4126605 8,12 8,12 Z" fill={smileFill} />
+                </g>
               </g>
             </g>
-          </g>
-        </svg>
+          </svg>
+        )}
       </Box>
       
       {showTextBlock ? (

--- a/packages/design-system/src/components/brand/Logo.tsx
+++ b/packages/design-system/src/components/brand/Logo.tsx
@@ -3,16 +3,18 @@
 import { Box } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import Heading from '../headings/Heading';
+import Icon from '../icons/Icon';
 import type { LogoProps } from '../../types';
 
 export default function Logo({ 
   name = 'NX°', 
   children, 
   subtitle, 
-  icon,
+  icon = "pingpong",
   favicon = false, 
   faceColor,
   smileColor,
+  iconSize = 30,
 }: LogoProps) {
 
   const theme = useTheme();
@@ -34,8 +36,8 @@ export default function Logo({
       <Box
         aria-hidden="true"
         sx={{
-          width: 36,
-          height: 36,
+          width: iconSize,
+          height: iconSize,
           marginRight: 0.5,
           display: 'inline-flex',
           alignItems: 'center',
@@ -46,10 +48,10 @@ export default function Logo({
       >
         {icon ? (
           <Box sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
-            {icon}
+            <Icon icon={icon as any} color="secondary" size={iconSize} />
           </Box>
         ) : (
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" role="img" aria-label="NX Favicon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width={iconSize} height={iconSize} role="img" aria-label="NX Favicon">
             <g stroke="none" fill="none" fillRule="evenodd">
               <g>
                 <rect fillOpacity="0" x="0" y="0" width="24" height="24" />

--- a/packages/design-system/src/components/icons/Icon.tsx
+++ b/packages/design-system/src/components/icons/Icon.tsx
@@ -422,13 +422,21 @@ export const ICON_NAMES = Object.keys(ICON_COMPONENTS).sort() as IconName[];
 export type IconProps = {
   icon: IconName | (string & {});
   color?: SvgIconProps['color'];
+  size?: number | string;
 };
 
-export default function Icon({ icon, color = 'inherit' }: IconProps) {
+export default function Icon({ icon, color = 'inherit', size }: IconProps) {
   const IconComponent = ICON_COMPONENTS[icon];
 
   if (IconComponent) {
-    return <IconComponent color={color} />;
+    const resolvedSize = typeof size === 'number' ? `${size}px` : size;
+
+    return (
+      <IconComponent
+        color={color}
+        sx={resolvedSize ? { fontSize: resolvedSize } : undefined}
+      />
+    );
   }
 
   return <ErrorIcon color='warning' />;

--- a/packages/design-system/src/components/icons/SVGIcons/PingpongballIcon.tsx
+++ b/packages/design-system/src/components/icons/SVGIcons/PingpongballIcon.tsx
@@ -4,8 +4,8 @@ import { SvgIcon, useTheme } from '@mui/material';
 export default function PingpongballIcon(props: any) {
   const theme = useTheme();
 
-  const smile = '#fff';
-  const mainColor = theme.palette.primary.main;
+  const smile = theme.palette.background.default === '#fff' ? '#000' : '#fff';
+  const mainColor = theme.palette.secondary.main;
 
   return (
     <SvgIcon {...props}>

--- a/packages/design-system/src/components/images/FeaturedImage.tsx
+++ b/packages/design-system/src/components/images/FeaturedImage.tsx
@@ -17,7 +17,7 @@ export default function FeaturedImage({
   const [status, setStatus] = useState<'loaded' | 'error'>('loaded');
   const hasIntrinsicRatio = typeof imageWidth === 'number' && typeof imageHeight === 'number' && imageWidth > 0 && imageHeight > 0;
   const resolvedPaddingTop = hasIntrinsicRatio && height == null ? `${(imageHeight / imageWidth) * 100}%` : undefined;
-  const resolvedHeight = height ?? (hasIntrinsicRatio ? 0 : 320);
+  const resolvedHeight = height ?? (hasIntrinsicRatio ? 0 : 220);
 
   return (
     <Box

--- a/packages/design-system/src/components/layout/Footer.tsx
+++ b/packages/design-system/src/components/layout/Footer.tsx
@@ -1,9 +1,99 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
 import { AppBar, Box, Toolbar } from '@mui/material';
 import Heading from '../headings/Heading';
 
 export default function Footer() {
+  const [isVisible, setIsVisible] = useState(false);
+  const [footerHeight, setFooterHeight] = useState(0);
+  const footerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    let hasTriggered = false;
+    const isVisibleRef = { current: false };
+
+    const evaluateFooter = () => {
+      const scrollTop = window.scrollY || window.pageYOffset || 0;
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+      const scrollHeight = document.documentElement.scrollHeight || 0;
+      const threshold = scrollHeight - viewportHeight - 220;
+      const contentFitsViewport = scrollHeight <= viewportHeight + 220;
+      const isNearBottom = scrollTop >= threshold;
+      const shouldShow = contentFitsViewport || isNearBottom;
+
+      if (!hasTriggered && shouldShow) {
+        hasTriggered = true;
+        isVisibleRef.current = true;
+        setIsVisible(true);
+        return;
+      }
+
+      if (scrollTop <= 0 && !contentFitsViewport) {
+        hasTriggered = false;
+        isVisibleRef.current = false;
+        setIsVisible(false);
+        return;
+      }
+
+      if (hasTriggered) {
+        isVisibleRef.current = true;
+        setIsVisible(true);
+      }
+    };
+
+    const handleScroll = () => {
+      evaluateFooter();
+    };
+
+    const updateFooterOffset = () => {
+      const height = footerRef.current?.offsetHeight ?? 0;
+      setFooterHeight(height);
+
+      const offset = isVisibleRef.current ? height : 0;
+      document.documentElement.style.setProperty('--site-footer-offset', `${offset}px`);
+      document.body.style.paddingBottom = `${offset}px`;
+    };
+
+    const runChecks = () => {
+      evaluateFooter();
+      updateFooterOffset();
+    };
+
+    runChecks();
+
+    const frameId = window.requestAnimationFrame(runChecks);
+    const timer = window.setTimeout(runChecks, 0);
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleScroll);
+    window.addEventListener('resize', updateFooterOffset);
+    window.addEventListener('load', runChecks);
+    window.addEventListener('pageshow', runChecks);
+
+    const observer = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(updateFooterOffset)
+      : null;
+
+    if (footerRef.current && observer) {
+      observer.observe(footerRef.current);
+    }
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.clearTimeout(timer);
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
+      window.removeEventListener('resize', updateFooterOffset);
+      window.removeEventListener('load', runChecks);
+      window.removeEventListener('pageshow', runChecks);
+      observer?.disconnect();
+    };
+  }, []);
+
   return (
     <AppBar
+      ref={footerRef as React.Ref<HTMLElement>}
       component="footer"
       position="fixed"
       color="transparent"
@@ -12,6 +102,10 @@ export default function Footer() {
       sx={{
         top: 'auto',
         bottom: 0,
+        transform: isVisible ? 'translateY(0)' : 'translateY(100%)',
+        opacity: isVisible ? 1 : 0,
+        pointerEvents: isVisible ? 'auto' : 'none',
+        transition: 'transform 180ms ease, opacity 180ms ease',
         backgroundColor: 'color-mix(in srgb, var(--surface-page) 72%, transparent)',
         backdropFilter: 'blur(14px) saturate(130%)',
         WebkitBackdropFilter: 'blur(14px) saturate(130%)',

--- a/packages/design-system/src/components/layout/Header.tsx
+++ b/packages/design-system/src/components/layout/Header.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTheme } from '@mui/material/styles';
 import Logo from '../brand/Logo';
 import type { SiteHeaderProps } from '../../types';
 
@@ -8,8 +7,11 @@ export default function Header({
   title,
   actions,
   icon,
+  iconSize = 36,
+  homeHref = '/',
+  logoSrc,
+  logoAlt,
 }: SiteHeaderProps) {
-  const theme = useTheme();
 
   return (
     <header>
@@ -20,18 +22,30 @@ export default function Header({
 
         <div aria-label="Logo and title" style={{ display: 'flex', alignItems: 'center', gap: '1rem', flex: 1 }}>
           <a
-            href="/"
+            href={homeHref}
             aria-label={`Go to ${title} home`}
             title={title}
             style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', color: 'inherit', textDecoration: 'none' }}
           >
-            <Logo 
-              name={title} 
-              icon={icon}
-              faceColor={theme.palette.secondary.main} 
-              smileColor={theme.palette.background.default}>
+            {icon || logoSrc ? (
+              <div style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                {icon ? (
+                  <Logo icon={icon} iconSize={iconSize}>
+                    {title}
+                  </Logo>
+                ) : (
+                  <img
+                    src={logoSrc}
+                    alt={logoAlt || title}
+                    style={{ width: iconSize, height: iconSize, objectFit: 'contain' }}
+                  />
+                )}
+              </div>
+            ) : (
+              <Logo icon={icon} iconSize={iconSize}>
                 {title}
-            </Logo>
+              </Logo>
+            )}
           </a>
         </div>
         

--- a/packages/design-system/src/components/layout/Header.tsx
+++ b/packages/design-system/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import type { SiteHeaderProps } from '../../types';
 export default function Header({
   title,
   actions,
+  icon,
 }: SiteHeaderProps) {
   const theme = useTheme();
 
@@ -26,6 +27,7 @@ export default function Header({
           >
             <Logo 
               name={title} 
+              icon={icon}
               faceColor={theme.palette.secondary.main} 
               smileColor={theme.palette.background.default}>
                 {title}

--- a/packages/design-system/src/components/navigation/Share.tsx
+++ b/packages/design-system/src/components/navigation/Share.tsx
@@ -215,8 +215,8 @@ export default function Share({
         open={open}
         anchorEl={anchorEl}
         onClose={handleClose}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Box sx={{ p: 1.5, minWidth: 220 }}>
           <Stack spacing={gap} role="menu" aria-label="Share menu">
@@ -269,8 +269,8 @@ export default function Share({
         open={copiedOpen}
         anchorEl={copiedAnchorEl}
         onClose={handleCopiedClose}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
         disableRestoreFocus
       >
         <Box role="status" sx={{ px: 1.5, py: 1 }}>

--- a/packages/design-system/src/components/navigation/SiteNav.tsx
+++ b/packages/design-system/src/components/navigation/SiteNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, useEffect, useState, type ReactNode } from 'react';
 import type { SiteNavProps, T_NavNode } from '../../types';
 import List from '../lists/List';
 import ListItem from '../lists/ListItem';
@@ -27,12 +27,36 @@ function isSuppressedHomeItem(item: T_NavNode, depth: number): boolean {
   return title === 'home' || path === '/';
 }
 
+function normalizeNavPath(path: string): string {
+  if (!path || path === '/') {
+    return '/';
+  }
+
+  const trimmed = path.trim();
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+function isOnCurrentPath(itemPath: string, currentPath: string): boolean {
+  if (!currentPath || !itemPath || itemPath === '#') {
+    return false;
+  }
+
+  const normalizedCurrentPath = normalizeNavPath(currentPath);
+  const normalizedItemPath = normalizeNavPath(itemPath);
+
+  if (normalizedItemPath === '/') {
+    return normalizedCurrentPath !== '/';
+  }
+
+  return normalizedCurrentPath === normalizedItemPath || normalizedCurrentPath.startsWith(`${normalizedItemPath}/`);
+}
 
 function renderNavItems(
   items: T_NavNode[],
   navigateTo?: (path: string, item: T_NavNode) => void,
   depth = 0,
-  keyPrefix = 'nav'
+  keyPrefix = 'nav',
+  currentPath = '',
 ): ReactNode {
   if (!Array.isArray(items) || !items.length) {
     return null;
@@ -48,13 +72,17 @@ function renderNavItems(
         const key = `${keyPrefix}-${index}-${item.title || item.slug || item.path || 'node'}`;
         const hasChildren = Array.isArray(item.children) && item.children.length > 0;
         const label = item.title || 'Untitled';
+        const itemPath = getNavPath(item);
+        const isCurrentPath = Boolean(currentPath && itemPath && currentPath === itemPath);
+        const shouldRenderChildren = Boolean(hasChildren && isOnCurrentPath(itemPath, currentPath));
 
         return (
           <Fragment key={key}>
             <ListItem disablePadding>
               <ListItemButton
+                disabled={isCurrentPath}
                 onClick={() => {
-                  navigateTo?.(getNavPath(item), item);
+                  navigateTo?.(itemPath, item);
                 }}
                 sx={{
                   pl: 1.5 + depth * 2,
@@ -64,6 +92,7 @@ function renderNavItems(
                 }}
               >
                 <ListItemText
+
                   primary={label}
                   sx={{ my: 0 }}
                   primaryTypographyProps={{
@@ -74,7 +103,7 @@ function renderNavItems(
                 />
               </ListItemButton>
             </ListItem>
-            {hasChildren ? renderNavItems(item.children as T_NavNode[], navigateTo, depth + 1, key) : null}
+            {shouldRenderChildren ? renderNavItems(item.children as T_NavNode[], navigateTo, depth + 1, key, currentPath) : null}
           </Fragment>
         );
       })}
@@ -83,5 +112,16 @@ function renderNavItems(
 }
 
 export default function SiteNav({ items, navigateTo }: SiteNavProps) {
-  return renderNavItems(items, navigateTo);
+  const [currentPath, setCurrentPath] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const pathname = window.location.pathname;
+    setCurrentPath(pathname.endsWith('/') && pathname !== '/' ? pathname.slice(0, -1) : pathname);
+  }, []);
+
+  return renderNavItems(items, navigateTo, 0, 'nav', currentPath);
 }

--- a/packages/design-system/src/types.d.ts
+++ b/packages/design-system/src/types.d.ts
@@ -21,6 +21,7 @@ export type LogoProps = {
 	name?: string;
 	children?: ReactNode;
 	subtitle?: string;
+	icon?: ReactNode;
 	favicon?: boolean;
 	faceColor?: string;
 	smileColor?: string;
@@ -180,6 +181,7 @@ export type SiteHeaderProps = {
 	homeHref: string;
 	logoSrc: string;
 	logoAlt?: string;
+	icon?: ReactNode;
 	navItems: ReactNode;
 	actions?: ReactNode;
 };

--- a/packages/design-system/src/types.d.ts
+++ b/packages/design-system/src/types.d.ts
@@ -25,6 +25,7 @@ export type LogoProps = {
 	favicon?: boolean;
 	faceColor?: string;
 	smileColor?: string;
+	iconSize?: number;
 };
 
 export type DesignSystemProviderProps = {
@@ -178,11 +179,12 @@ export type ShareProps = {
 export type SiteHeaderProps = {
 	title: string;
 	description?: string;
-	homeHref: string;
-	logoSrc: string;
-	logoAlt?: string;
 	icon?: ReactNode;
-	navItems: ReactNode;
+	iconSize?: number;
+	homeHref?: string;
+	logoSrc?: string;
+	logoAlt?: string;
+	navItems?: ReactNode;
 	actions?: ReactNode;
 };
 

--- a/packages/design-system/tests/components/brand/brand.test.tsx
+++ b/packages/design-system/tests/components/brand/brand.test.tsx
@@ -20,10 +20,10 @@ describe('brand components', () => {
   });
 
   it('renders a provided icon instead of the fallback svg', () => {
-    render(<Logo icon={<span data-testid="custom-icon">custom</span>} />);
+    const { container } = render(<Logo icon={<span data-testid="custom-icon">custom</span>} />);
 
     expect(screen.getByTestId('custom-icon')).toBeTruthy();
-    expect(document.querySelector('svg[aria-label="NX Favicon"]')).toBeNull();
+    expect(container.querySelector('svg[aria-label="NX Favicon"]')).toBeNull();
   });
 
   it('uses custom face and smile colors when provided', () => {

--- a/packages/design-system/tests/components/brand/brand.test.tsx
+++ b/packages/design-system/tests/components/brand/brand.test.tsx
@@ -19,11 +19,11 @@ describe('brand components', () => {
     expect(screen.queryByText('NX')).toBeNull();
   });
 
-  it('renders a provided icon instead of the fallback svg', () => {
-    const { container } = render(<Logo icon={<span data-testid="custom-icon">custom</span>} />);
+  it('renders a provided icon name instead of the fallback svg', () => {
+    const { container } = render(<Logo icon="home" />);
 
-    expect(screen.getByTestId('custom-icon')).toBeTruthy();
     expect(container.querySelector('svg[aria-label="NX Favicon"]')).toBeNull();
+    expect(container.querySelectorAll('svg').length).toBeGreaterThan(0);
   });
 
   it('uses custom face and smile colors when provided', () => {

--- a/packages/design-system/tests/components/brand/brand.test.tsx
+++ b/packages/design-system/tests/components/brand/brand.test.tsx
@@ -19,6 +19,13 @@ describe('brand components', () => {
     expect(screen.queryByText('NX')).toBeNull();
   });
 
+  it('renders a provided icon instead of the fallback svg', () => {
+    render(<Logo icon={<span data-testid="custom-icon">custom</span>} />);
+
+    expect(screen.getByTestId('custom-icon')).toBeTruthy();
+    expect(document.querySelector('svg[aria-label="NX Favicon"]')).toBeNull();
+  });
+
   it('uses custom face and smile colors when provided', () => {
     const { container } = render(<Logo faceColor="#123456" smileColor="#abcdef" />);
 


### PR DESCRIPTION
This pull request introduces several improvements and new features across the codebase, focusing on enhanced theme mode handling, Uberedux state integration and preview, and improved branding flexibility. The most important changes are summarized below.

**Theme Mode Handling and Tests**

* Added support for a `'system'` theme mode preference, which resolves to the user's OS/browser color scheme, and refactored the theme context to use this logic (`ThemeModeContext.tsx`, `page.tsx`). [[1]](diffhunk://#diff-86e925fe03e0b3783ca3ba22f51415ce88de9458b610ec281d7ec7967ee6239bR7) [[2]](diffhunk://#diff-86e925fe03e0b3783ca3ba22f51415ce88de9458b610ec281d7ec7967ee6239bL15-R16) [[3]](diffhunk://#diff-86e925fe03e0b3783ca3ba22f51415ce88de9458b610ec281d7ec7967ee6239bR32-R45) [apps/www/app/[[...slug]]/page.tsxL127-R131](diffhunk://#diff-026c0f6627ce0910d35012dbf4479dbce4dd54ad25e9ec8f55859b8424aab955L127-R131))
* Added unit tests for the new `resolveThemeMode` function to ensure correct behavior based on browser/system preferences (`themeModeContext.test.tsx`).

**Uberedux State Integration**

* Introduced an `Init` component to initialize Uberedux state on app mount, and integrated it into the root layout (`Init.tsx`, `layout.tsx`). [[1]](diffhunk://#diff-7f82ace685a4e40b66d760412d9f5f1094f7932b0d38720dd3c145f3db7ed265R1-R27) [[2]](diffhunk://#diff-47af82cc8de9eeedfbf47f06abd43eee8f4306a2eb2282a7af5b8825d9055c3dR8) [[3]](diffhunk://#diff-47af82cc8de9eeedfbf47f06abd43eee8f4306a2eb2282a7af5b8825d9055c3dR78)
* Added an `UbereduxStatePreview` component and rendered it in an aside on content pages for state inspection (`UbereduxStatePreview.tsx`, `page.tsx`). ([apps/www/app/NX/DesignSystem/UbereduxStatePreview.tsxR1-R22](diffhunk://#diff-ee2523b5d2eaf8fbb468829a346bd9d4e363584ab7a08d6c46b64f85ea664720R1-R22), [apps/www/app/[[...slug]]/page.tsxL200-R209](diffhunk://#diff-026c0f6627ce0910d35012dbf4479dbce4dd54ad25e9ec8f55859b8424aab955L200-R209))

**Branding and Icon Customization**

* Updated the `Logo` component to accept a customizable `icon` and `iconSize`, defaulting to "pingpong", and adjusted rendering to use the new `Icon` component. Also improved the `Icon` component to support sizing and color, and updated the pingpong icon colors for better theming (`Logo.tsx`, `Icon.tsx`, `PingpongballIcon.tsx`). [[1]](diffhunk://#diff-b1032034fcb6e30f9a43fb30037b6c890ec9eb8cd1638fa3f5fe280fc7b31b7fR6-R17) [[2]](diffhunk://#diff-b1032034fcb6e30f9a43fb30037b6c890ec9eb8cd1638fa3f5fe280fc7b31b7fL36-R40) [[3]](diffhunk://#diff-b1032034fcb6e30f9a43fb30037b6c890ec9eb8cd1638fa3f5fe280fc7b31b7fL46-R54) [[4]](diffhunk://#diff-b1032034fcb6e30f9a43fb30037b6c890ec9eb8cd1638fa3f5fe280fc7b31b7fR68) [[5]](diffhunk://#diff-84b7f69ab57536203f7bd7a21ab80762b57a541727da3270531557013d82e1bfR425-R439) [[6]](diffhunk://#diff-a8af0a3c9e9959cbd39c9b1c5c6bb604b9dd226fa68a023e8ccf3df2c474ee3aL7-R8)
* Changed the default icon for the homepage and Git tech stack page, and removed the icon from the help page markdown for better branding consistency (`index.md`, `git.md`, `help/index.md`). [[1]](diffhunk://#diff-51b3fe8760ce718bbe6385b172f74c6d16c68da7474a722eec19d90055d30243L6-R14) [[2]](diffhunk://#diff-79756c3300c029041bc4268248f984a01cda112215445712dcf684b663d4fbe6L6-R6) [[3]](diffhunk://#diff-6acb38437de8c16d7a7602c592bd4adc229687be08819a1d159a33d86b009fdbL1-L9)

**Documentation Updates**

* Moved Storybook instructions from the main `README.md` to a dedicated `docs/storybook.md` file for clarity and easier access (`README.md`, `storybook.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-L26) [[2]](diffhunk://#diff-2ea669e1b31c2cfcdca0215bd9a4f6b32744d6d8e0886efc5a2ea2b03e60ad58R1-R5)

**Minor Content and UI Tweaks**

* Reduced the default height for featured images for a more compact layout (`FeaturedImage.tsx`).
* Removed an unused "redoc" page link from the FastAPI tech stack markdown (`fastapi.md`).