### PR TITLE
Refine nav drawer and page metadata

### DIFF
--- a/apps/www/app/NX/DesignSystem/HeaderActions.tsx
+++ b/apps/www/app/NX/DesignSystem/HeaderActions.tsx
@@ -8,9 +8,16 @@ import ThemeModeToggle from './ThemeModeToggle';
 export default function HeaderActions({ navItems }: { navItems: ReactNode }) {
   return (
     <Fragment>
-      <Share />
-      <ThemeModeToggle />
-      <MenuDrawer navItems={navItems} toggleAriaLabel="Toggle menu" />
+      <MenuDrawer
+        navItems={navItems}
+        actions={
+          <Fragment>
+            <Share />
+            <ThemeModeToggle />
+          </Fragment>
+        }
+        toggleAriaLabel="Toggle menu"
+      />
     </Fragment>
   );
 }

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -172,7 +172,7 @@ export default async function Page({ params }: T_PageProps) {
                     <DesignSystemSiteMain>
 
                         {pageDescription ? (
-                            <Heading variant="h2" style={{ marginBottom: '1rem' }} tone="secondary">
+                            <Heading variant="h3" style={{  }} tone="clay">
                                 {pageDescription}
                             </Heading>
                         ) : null}
@@ -190,12 +190,14 @@ export default async function Page({ params }: T_PageProps) {
                         ) : null}
                         
                         {breadcrumbItems.length ? (
-                            <div style={{ marginTop: '1.5rem', marginBottom: '0.5rem' }}>
+                            <div style={{ }}>
                                 <Breadcrumb items={breadcrumbItems} />
                             </div>
                         ) : null}
 
-                        <RenderMarkdown config={config}>{content}</RenderMarkdown>
+                        <RenderMarkdown config={config}>
+                            {content}
+                        </RenderMarkdown>
                     </DesignSystemSiteMain>
                     
                     {/* <aside aria-label="NX° Aside" style={{ marginTop: 50 }}>

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import '@nx/design-system/styles.css';
 import '@nx/design-system/site-layout.css';
 import fs from 'fs';
@@ -55,7 +55,6 @@ export const metadata: Metadata = {
   title: `${title}, ${description}`,
   description,
   manifest: '/manifest.webmanifest',
-  themeColor: pwaBackground,
   icons: {
     icon: [
       {
@@ -72,6 +71,10 @@ export const metadata: Metadata = {
     shortcut: defaultFavicon,
     apple: appleTouchIcon,
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: pwaBackground,
 };
 
 export default async function RootLayout({

--- a/apps/www/public/nx/markdown/experience/index.md
+++ b/apps/www/public/nx/markdown/experience/index.md
@@ -9,9 +9,7 @@ tags: experience, eras
 
 > [CleverText text="Spanning every era of web development"]
 
-We've been a part of the evolution from the Flash era with basic dial-up experiences to today's AI-enhanced, cloud-native web apps built on React and Next.js
-
-[PageLink icon="virus" url="https://notheretofuckspiders.art/fables/old-bull" title="The fable of the young bull and the old bull" description="A young bull and an old bull were standing on a hill overlooking a field full of cows." ]  
+We've been a part of the evolution from the Flash era with basic dial-up experiences to today's AI-enhanced, cloud-native web apps built on React and Next.js  
 
 **2000s: The Flash Era (Dial-up to Early Broadband)**
 

--- a/apps/www/public/nx/markdown/features/design-system.md
+++ b/apps/www/public/nx/markdown/features/design-system.md
@@ -5,7 +5,6 @@ description: Material UI
 slug: /features/design-system
 icon: design
 tags: features, design system, mui, material ui,
-image: https://live.staticflickr.com/65535/55139727398_05d97ed1d6_b.jpg
 ---
 ## No other design system sees the same breadth of adoption
 

--- a/apps/www/public/nx/markdown/features/index.md
+++ b/apps/www/public/nx/markdown/features/index.md
@@ -5,7 +5,6 @@ description: Powerful modern technologies
 slug: /features
 icon: tick
 tags: features
-image: https://live.staticflickr.com/65535/55327040507_6ebcd4873b_c.jpg
 ---
 - [Design System](/features/design-system)
 - [Progressive Web Apps](/features/pwa)

--- a/apps/www/public/nx/markdown/techstack/index.md
+++ b/apps/www/public/nx/markdown/techstack/index.md
@@ -1,7 +1,7 @@
 ---
 order: 441
 title: Techstack
-description: Built with Open Source
+description: Built on Open Source
 slug: /techstack
 icon: techstack
 tags: Techstack, Vercel, Firebase, Render, React, Python

--- a/apps/www/public/nx/markdown/techstack/python-3.md
+++ b/apps/www/public/nx/markdown/techstack/python-3.md
@@ -6,9 +6,7 @@ description: Central to AI and automation
 tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres
 icon: api
 image: https://live.staticflickr.com/65535/55198277139_08236ed419_b.jpg
----
-
-[PageLink icon="github" description="Open Source, production ready Python FastAPI/Postgres" title="goldlabelapps/python" url="https://github.com/goldlabelapps/python"]  
+--- 
 
 > [CleverText text="Readable syntax, massive library support"]  
 

--- a/packages/design-system/src/components/layout/MenuDrawer.tsx
+++ b/packages/design-system/src/components/layout/MenuDrawer.tsx
@@ -3,10 +3,11 @@
 import { useId, useState } from 'react';
 import { Box, Drawer } from '@mui/material';
 import IconButton from '../buttons/IconButton';
+import Heading from '../headings/Heading';
 import Icon from '../icons/Icon';
 import type { MenuDrawerProps } from '../../types';
 
-export default function MenuDrawer({ navItems, toggleAriaLabel = 'Toggle navigation menu' }: MenuDrawerProps) {
+export default function MenuDrawer({ navItems, actions, toggleAriaLabel = 'Toggle navigation menu' }: MenuDrawerProps) {
   const [open, setOpen] = useState(false);
   const navId = useId();
 
@@ -39,9 +40,33 @@ export default function MenuDrawer({ navItems, toggleAriaLabel = 'Toggle navigat
           },
         }}
       >
+        
+        {actions ? (
+          <Box sx={{ 
+            mt: 0, 
+            display: 'flex', 
+            flexWrap: 'wrap', 
+            alignItems: 'flex-start', 
+            justifyContent: 'space-between',
+            gap: 1 }}>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1 }}>
+              {actions}
+            </Box>
+            <IconButton
+              icon={<Icon icon="close" color="secondary" />}
+              ariaLabel="Close navigation menu"
+              onClick={handleClose}
+            />
+          </Box>
+        ) : null}
+
+        <Heading sx={{ mt: 2, mb: 1 }}>
+          Navigation
+        </Heading>
         <nav id={navId} aria-label="Primary navigation">
           {navItems}
         </nav>
+
       </Drawer>
     </Box>
   );

--- a/packages/design-system/src/types.d.ts
+++ b/packages/design-system/src/types.d.ts
@@ -190,6 +190,7 @@ export type SiteHeaderProps = {
 
 export type MenuDrawerProps = {
 	navItems: ReactNode;
+	actions?: ReactNode;
 	toggleAriaLabel?: string;
 };
 


### PR DESCRIPTION
Adds an optional `actions` slot to `MenuDrawer` and updates header usage so share/theme controls render inside the drawer alongside a close control and navigation heading. Also updates Next.js root config by moving `themeColor` from `metadata` to a new `viewport` export. Includes small content and presentation cleanups across markdown pages (removed select `image`/`PageLink` entries and copy tweaks) plus minor heading/breadcrumb styling adjustments on the slug page.