### PR TITLE
Clean up markdown content and frontmatter

### DIFF
--- a/apps/www/public/nx/markdown/experience/ai/index.md
+++ b/apps/www/public/nx/markdown/experience/ai/index.md
@@ -9,8 +9,3 @@ image: https://live.staticflickr.com/65535/55228044632_fbefe45525_b.jpg
 ---
 
 > [CleverText text="'Yeh... put that kind of AI into a drone with a gun & you've got a big problem' Bloke down the pub said, yesterday"]
-
-[PageLink icon="right" url="/experience/ai/prompts" title="Proper Prompt Engineering" description="Simple cut+paste propmts to try" ]  
-[PageLink icon="right" url="/experience/ai/open-claw" title="Open Claw" description="Claw Ensemble Learning is a meta-learning framework" ]  
-[PageLink icon="right" url="/experience/ai/ollama" title="Ollama" description="Run LLMs on your own device" ]  
-[PageLink icon="right" url="/experience/ai/phi-3" title="Phi-3" description="High performance Microsoft models" ]  

--- a/apps/www/public/nx/markdown/experience/ai/ollama.md
+++ b/apps/www/public/nx/markdown/experience/ai/ollama.md
@@ -5,7 +5,6 @@ description: Run LLMs on your own device
 slug: /experience/ai/ollama
 icon: ai
 tags: ai, ollama
-image: https://live.staticflickr.com/65535/55228044632_fbefe45525_b.jpg
 ---
 
 > [CleverText text="Are you breaching GDPR?"]
@@ -15,5 +14,3 @@ Use [Ollama](https://ollama.com/) to run large language models (LLMs) locally, e
 Ollama offers an AI assistant that's as accessible from your phone or computer, without any need to install anything locally—bringing high-performance language models right into your own software
 
 Get immediate help with translation, writing assistance, scheduling reminders. You can learn new skills on demand. All this happens in a secure manner where Ollama leverages powerful GPUs without sharing or transmitting sensitive data overseas—keeping it all within German servers for those who want the full local experience while adhering to strict privacy laws like GDPR.
-
-[PageLink icon="doc" url="https://ed-tech.co/courses" title="EdTech°" description="Learn how to run large language models (LLMs) locally" ] 

--- a/apps/www/public/nx/markdown/experience/ai/open-claw.md
+++ b/apps/www/public/nx/markdown/experience/ai/open-claw.md
@@ -5,7 +5,6 @@ description: Claw Ensemble Learning is a meta-learning framework
 slug: /experience/ai/open-claw
 icon: ai
 tags: ai
-image: https://live.staticflickr.com/65535/55228044632_fbefe45525_b.jpg
 ---
 
 > [CleverText text="Yeh. If you put that kind of AI into a drone with a gun... then you've got a big problem. Bloke down the pub said, yesterday"]

--- a/apps/www/public/nx/markdown/experience/ai/phi-3.md
+++ b/apps/www/public/nx/markdown/experience/ai/phi-3.md
@@ -5,11 +5,8 @@ description: High performance Microsoft models
 slug: /experience/ai/phi-3
 icon: ai
 tags: ai, ollama, phi-3,
-image: https://live.staticflickr.com/65535/55228044632_fbefe45525_b.jpg
 ---
 
 > [CleverText text="Are you breaching GDPR?"]
 
 [Phi-3](https://azure.microsoft.com/en-us/blog/introducing-phi-3-redefining-whats-possible-with-slms/) is a family of lightweight, high-performance language models developed by Microsoft. In this project, you can run Phi-3 locally using Ollama for private, fast, and secure AI-powered document management. Many other LLMs, both free and commercial, are also available.
-
-[PageLink icon="doc" url="https://ed-tech.co/courses" title="EdTech°" description="Learn how to run large language models (LLMs) locally" ] 

--- a/apps/www/public/nx/markdown/experience/ai/prompts.md
+++ b/apps/www/public/nx/markdown/experience/ai/prompts.md
@@ -5,7 +5,6 @@ description: Proper Prompt Engineering
 slug: /experience/ai/prompts
 icon: ai
 tags: ai, ollama
-image: https://live.staticflickr.com/65535/55228044632_fbefe45525_b.jpg
 ---
 > [CleverText text="Simple cut+paste propmts to try "]
 

--- a/apps/www/public/nx/markdown/experience/techstack/git.md
+++ b/apps/www/public/nx/markdown/experience/techstack/git.md
@@ -6,7 +6,6 @@ slug: /experience/techstack/git
 icon: github
 tags: open source, free, git, github
 --- 
-]
 
 Progress in software is only possible by standing on the shoulders of giants. Learning from, building upon, and contributing to the work of those who came before us. 
 

--- a/apps/www/public/nx/markdown/experience/techstack/index.md
+++ b/apps/www/public/nx/markdown/experience/techstack/index.md
@@ -6,9 +6,3 @@ slug: /experience/techstack
 icon: experience
 tags: experience, Techstack, Vercel, Firebase, Render, React, nx
 ---
-
-[PageLink url="/experience/techstack/typescript" icon="right" title="TypeScript" description="Fullstack Node and React"]  
-
-[PageLink url="/experience/techstack/nextjs" icon="right" title="Next.js" description="Statically typed superset of JavaScript"]  
-
-[PageLink url="/experience/techstack/react" icon="right" title="React" description="JavaScript functions that return markup"]  

--- a/apps/www/public/nx/markdown/techstack/react.md
+++ b/apps/www/public/nx/markdown/techstack/react.md
@@ -5,7 +5,6 @@ description: by facebook
 slug: /techstack/react
 tags: javascript, nextjs, react
 icon: js
-image: https://live.staticflickr.com/65535/55042136837_2c9d12d414_b.jpg
 ---
 
 > [CleverText text="React apps are made out of components."]

--- a/apps/www/public/nx/markdown/techstack/tsvector.md
+++ b/apps/www/public/nx/markdown/techstack/tsvector.md
@@ -8,8 +8,6 @@ icon: api
 image: https://live.staticflickr.com/65535/55198277139_08236ed419_b.jpg
 ---
 
-[PageLink icon="github" description="Open Source, production ready Python FastAPI/Postgres app for NX" title="goldlabelapps/python" url="https://github.com/goldlabelapps/python"]  
-
 > [CleverText text="Superfast search with tsvector"]  
 
 PostgreSQL provides two data types that are designed to support full text search, which is the activity of searching through a collection of natural-language documents to locate those that best match a query. The tsvector type represents a document in a form optimized for text search; the tsquery type similarly represents a text query.

--- a/apps/www/public/nx/markdown/techstack/typescript.md
+++ b/apps/www/public/nx/markdown/techstack/typescript.md
@@ -11,7 +11,3 @@ tags: Techstack, javascript, typescript
 > [CleverText text="JavaScript whatever the weather "]  
 
 TypeScript is a powerful, statically typed superset of JavaScript that brings type safety, better tooling, and improved developer productivity to modern web development. It helps catch errors early, makes code easier to maintain, and enables you to build large, robust applications with confidence.
-
-[PageLink icon="js" title="NextJS" url="/techstack/nextjs"] 
-
-[PageLink icon="js" title="React" url="/techstack/react"]  


### PR DESCRIPTION
Remove PageLink components from index pages and individual AI/techstack pages, remove redundant image frontmatter fields, and fix a stray `]` in git.md.