### PR TITLE
Update content and minor UI fixes

### DIFF
--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -172,7 +172,7 @@ export default async function Page({ params }: T_PageProps) {
                     <DesignSystemSiteMain>
 
                         {pageDescription ? (
-                            <Heading variant="h3" style={{  }} tone="clay">
+                            <Heading variant="h3" style={{  }}>
                                 {pageDescription}
                             </Heading>
                         ) : null}

--- a/apps/www/public/nx/markdown/experience/solo.md
+++ b/apps/www/public/nx/markdown/experience/solo.md
@@ -6,7 +6,9 @@ slug: /experience/solo
 icon: experience
 ---
 
-> A very real emerging category of role is Not an freelancer. Not an agency. Not an employee.
+> [CleverText text="Not an freelancer. Not an agency. Not an employee."]
+
+A very real emerging category of role is the high trust solo developer
 
 - understand business problems
 - architect systems
@@ -15,14 +17,7 @@ icon: experience
 - coordinate specialists only when needed
 - deliver outcomes without organisational drag
 
-That model can absolutely work now because AI massively increases individual throughput.
-
-The key change is this:
-
-Previously: bigger project → bigger team
-
-Now: bigger project → better operator
-
+That model can absolutely work now because AI massively increases individual throughput. The key change is this: Previously: bigger project → bigger team Now: bigger project → better operator
 
 #### Fractional Technical Partner
 

--- a/apps/www/public/nx/markdown/experience/techstack/index.md
+++ b/apps/www/public/nx/markdown/experience/techstack/index.md
@@ -6,3 +6,8 @@ slug: /experience/techstack
 icon: experience
 tags: experience, Techstack, Vercel, Firebase, Render, React, nx
 ---
+
+
+> [CleverText text="Experience, Techstack, Vercel, Firebase, Render, React"]
+
+

--- a/apps/www/public/nx/markdown/features/design-system.md
+++ b/apps/www/public/nx/markdown/features/design-system.md
@@ -6,7 +6,8 @@ slug: /features/design-system
 icon: design
 tags: features, design system, mui, material ui,
 ---
-## No other design system sees the same breadth of adoption
+
+> [CleverText text="No other design system sees the same breadth of adoption as Material"]
 
 Material UI, commonly known as MUI, has grown into the most widely used React component library and design system. Its popularity comes from a mix of practical engineering benefits: a complete suite of pre-built components, a predictable theming model, strong TypeScript support, and an ecosystem that stays aligned with modern React patterns.
 
@@ -14,7 +15,7 @@ MUI solves the design system gap for teams that need polished UI out of the box 
 
 NX uses MUI as the foundation for its own theme cartridge, extending the base components with custom styling, utility components, and layout primitives. It gives a consistent look, predictable behaviour, and a reliable way to handle UI complexity without reinventing the basics.
 
-# Design System
+## Design System
 
 This package is the shared home for presentation-layer work in NX°. It is meant to own the frontend experience beyond a simple color theme, including:
 

--- a/apps/www/public/nx/markdown/features/index.md
+++ b/apps/www/public/nx/markdown/features/index.md
@@ -6,7 +6,5 @@ slug: /features
 icon: tick
 tags: features
 ---
-- [Design System](/features/design-system)
-- [Progressive Web Apps](/features/pwa)
-- [Uberedux](/features/uberedux)
-- [Shortcodes](/features/shortcodes)
+
+> [CleverText text="Design System, Uberedux, Shortcodes"]  

--- a/apps/www/public/nx/markdown/features/pwa.md
+++ b/apps/www/public/nx/markdown/features/pwa.md
@@ -4,8 +4,7 @@ title: PWA
 description: Progressive Web Apps
 slug: /features/pwa
 icon: mobile
-tags: features, pwa, 
-image: https://live.staticflickr.com/65535/53160956233_21a5d3e088_b.jpg
+tags: features, pwa
 ---
 
 > [CleverText text="Installable on any phone"]

--- a/apps/www/public/nx/markdown/features/shortcodes.md
+++ b/apps/www/public/nx/markdown/features/shortcodes.md
@@ -5,7 +5,6 @@ description: A WordPress concept
 slug: /features/shortcodes
 icon: wordpress
 tags: wordpress
-image: https://live.staticflickr.com/8504/8434232637_ddd4fd7cf1_z.jpg
 ---
 
 > [CleverText text="How Shortcodes Work"] 
@@ -24,7 +23,7 @@ By using shortcodes, content creators can
 - Keep markdown files clean and readable
 - Empower non-developers to enhance content without editing code
 
-#### Example Usage
+## Example Usage
 
 Suppose you want to embed a line of chatbot response style text in your markdown, you would do this
 

--- a/apps/www/public/nx/markdown/features/uberedux.md
+++ b/apps/www/public/nx/markdown/features/uberedux.md
@@ -4,8 +4,7 @@ title: Uberedux
 description: Zero config Redux pattern
 slug: /features/uberedux
 icon: js
-tags: features, pwa, 
-image: https://live.staticflickr.com/65535/54353995935_a904d504aa_b.jpg
+tags: features, pwa
 ---
 
 > [CleverText text="Otherwise you'd be back in jQuery callback hell. Nobody wants that."] 

--- a/apps/www/public/nx/markdown/techstack/python-3.md
+++ b/apps/www/public/nx/markdown/techstack/python-3.md
@@ -5,7 +5,6 @@ title: Python 3
 description: Central to AI and automation
 tags: NX, Features, Python, Cartridges, FastAPI, tsvector, Postgres
 icon: api
-image: https://live.staticflickr.com/65535/55198277139_08236ed419_b.jpg
 --- 
 
 > [CleverText text="Readable syntax, massive library support"]  

--- a/apps/www/public/nx/markdown/techstack/tsvector.md
+++ b/apps/www/public/nx/markdown/techstack/tsvector.md
@@ -5,7 +5,6 @@ title: tsvector
 description: Superfast full text search
 tags: Python, FastAPI, tsvector, Postgres, PostgreSQL, data types,
 icon: api
-image: https://live.staticflickr.com/65535/55198277139_08236ed419_b.jpg
 ---
 
 > [CleverText text="Superfast search with tsvector"]  
@@ -17,7 +16,7 @@ PostgreSQL provides two data types that are designed to support full text search
 What makes tsvector brilliant is its ability to turn messy, unstructured text into a lightning-fast, searchable format right inside your database. With tsvector, you get powerful, language-aware search capabilities—ranking, stemming, and relevance without leaving Postgres. It’s great for building search features that feel instant and smart.
 
 
-### Full-Text Search
+## Full-Text Search
 
 The prospects table includes a **search_vector** column computed from all text fields on insert/update. A GIN index enables fast, scalable full-text search:
 

--- a/packages/design-system/src/components/icons/SVGIcons/WordpressIcon.tsx
+++ b/packages/design-system/src/components/icons/SVGIcons/WordpressIcon.tsx
@@ -3,7 +3,7 @@ import { useTheme, SvgIcon } from '@mui/material';
 
 export default function WordpressIcon(props: any) {
   const theme = useTheme();
-  let color1 = theme.palette.primary.main;
+  let color1 = theme.palette.secondary.main;
 
   return (
     <SvgIcon {...props}>


### PR DESCRIPTION
- Replace heading tone prop and use secondary color for WordPress icon
- Refactor several markdown files to use CleverText shortcodes for descriptions
- Remove hardcoded Flickr image URLs from frontmatter
- Fix heading levels (h1→h2) in design-system, shortcodes, and tsvector docs
- Collapse verbose paragraph blocks in solo.md