### PR TITLE
Add CI workflow for tests and type checks

### DIFF
--- a/.github/workflows/test-and-typecheck.yml
+++ b/.github/workflows/test-and-typecheck.yml
@@ -1,0 +1,36 @@
+name: Test and Type Check
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
Adds a new GitHub Actions workflow that runs on all pull requests and on pushes to main/master. The job checks out code, sets up Node from .nvmrc with pnpm caching, installs dependencies with a frozen lockfile, then runs `pnpm type-check` and `pnpm test`.