### PR TITLE
Add @nx/shortcodes package and expand monorepo test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@
 
 > NX° is a powerful JavaScript framework for creating apps to meet multiple projects and needs. Built for creators, coders, collaborators, and audiences who need a flexible space to publish, discover, and engage with rich content [more...](./docs/README.md)
 
+## Test Suite
+
+The NX° test suite validates apps, shared packages, and monorepo guardrails in one place. It combines Jest (apps), Vitest (design system), and Node/TSX tests (shared packages + root checks), then prints a single end-of-run summary. Run from repository root
+
+```bash
+pnpm test
+```
+
+#### Understand the code
+
+- [Monorepo test runner](tests/run-monorepo-tests.mjs)
+- [Monorepo coverage runner](tests/run-monorepo-coverage.mjs)
+- [Root framework guard tests](tests/testing-framework.test.mjs)
+- [WWW integration test example](apps/www/tests/integration/nav-theme-toggle.test.tsx)
+- [NHTFS API unit test example](apps/nhtfs/tests/unit/api/getEndpoints.test.ts)
+- [Design-system navigation test example](packages/design-system/tests/components/navigation/navigation.test.tsx)
+- [Shortcodes parser package test example](packages/shortcodes/tests/parser.test.ts)
+
 ## Bash CLI
 
 The repo includes a bash-only workspace CLI in [shell/nx.sh](shell/nx.sh). It works from a fresh clone before any package install:

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "packageManager": "pnpm@11.13.0",
   "scripts": {
     "dev": "next dev -p 2000 --webpack",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev -p 2000 --webpack",
     "build": "next build --webpack",
     "start": "next start",
+    "test": "node --test tests/**/*.test.mjs",
     "lint": "eslint",
     "clean": "pnpm run kill && bash app/NX/lib/bash/clean.sh",
     "kill": "bash app/NX/lib/bash/kill.sh",

--- a/apps/admin/tests/smoke.test.mjs
+++ b/apps/admin/tests/smoke.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('admin app has expected runtime entrypoints', () => {
+  assert.equal(existsSync(path.join(appRoot, 'app', 'layout.tsx')), true);
+  assert.equal(existsSync(path.join(appRoot, 'next.config.ts')), true);
+  assert.equal(existsSync(path.join(appRoot, 'public')), true);
+});

--- a/apps/nhtfs/package.json
+++ b/apps/nhtfs/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "3.0.1",
   "name": "nhtfs",
   "description": "NX°",
   "packageManager": "pnpm@11.13.0",

--- a/apps/nhtfs/tests/unit/api/index.test.ts
+++ b/apps/nhtfs/tests/unit/api/index.test.ts
@@ -1,0 +1,14 @@
+import { getBaseurl, getEndpoints, makeRes, makeTime } from '@/app/api';
+import { getBaseurl as getBaseurlLib } from '@/app/api/lib/getBaseurl';
+import { getEndpoints as getEndpointsLib } from '@/app/api/lib/getEndpoints';
+import { makeRes as makeResLib } from '@/app/api/lib/makeRes';
+import { makeTime as makeTimeLib } from '@/app/api/lib/makeTime';
+
+describe('api/index exports', () => {
+  it('re-exports API helpers from their source modules', () => {
+    expect(getBaseurl).toBe(getBaseurlLib);
+    expect(getEndpoints).toBe(getEndpointsLib);
+    expect(makeRes).toBe(makeResLib);
+    expect(makeTime).toBe(makeTimeLib);
+  });
+});

--- a/apps/nhtfs/tests/unit/designsystem/themeModeContext.test.tsx
+++ b/apps/nhtfs/tests/unit/designsystem/themeModeContext.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+const mockReadPersistedThemeModeFromStorage = jest.fn();
+const mockSetPersistedThemeMode = jest.fn((mode: 'light' | 'dark') => ({ type: 'theme/setPersistedThemeMode', payload: mode }));
+const mockStoreDispatch = jest.fn();
+const mockStoreGetState = jest.fn(() => ({}));
+const mockPersistorSubscribe = jest.fn(() => jest.fn());
+const mockPersistorGetState = jest.fn(() => ({ bootstrapped: false }));
+const mockSelectPersistedThemeMode = jest.fn(() => null);
+
+jest.mock('@nx/design-system', () => ({
+  DesignSystemProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@nx/uberedux', () => ({
+  readPersistedThemeModeFromStorage: () => mockReadPersistedThemeModeFromStorage(),
+  selectPersistedThemeMode: (...args: unknown[]) => mockSelectPersistedThemeMode(...args),
+  setPersistedThemeMode: (mode: 'light' | 'dark') => mockSetPersistedThemeMode(mode),
+  themePreferencePersistor: {
+    subscribe: (...args: unknown[]) => mockPersistorSubscribe(...args),
+    getState: (...args: unknown[]) => mockPersistorGetState(...args),
+  },
+  themePreferenceStore: {
+    dispatch: (...args: unknown[]) => mockStoreDispatch(...args),
+    getState: (...args: unknown[]) => mockStoreGetState(...args),
+  },
+}));
+
+import { ThemeModeProvider, resolveThemeMode, useThemeMode } from '@/app/NX/DesignSystem/ThemeModeContext';
+
+function Probe() {
+  const { mode } = useThemeMode();
+  return <span data-testid="mode">{mode}</span>;
+}
+
+describe('ThemeModeContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadPersistedThemeModeFromStorage.mockReturnValue(null);
+    mockSelectPersistedThemeMode.mockReturnValue(null);
+  });
+
+  it('resolveThemeMode handles explicit and fallback modes', () => {
+    expect(resolveThemeMode('dark')).toBe('dark');
+    expect(resolveThemeMode('light')).toBe('light');
+    expect(resolveThemeMode('system')).toBe('light');
+    expect(resolveThemeMode(undefined)).toBe('light');
+  });
+
+  it('throws when useThemeMode is called outside provider', () => {
+    expect(() => render(<Probe />)).toThrow('useThemeMode must be used within a ThemeModeProvider');
+  });
+
+  it('applies persisted mode and dispatches persisted theme updates', async () => {
+    mockReadPersistedThemeModeFromStorage.mockReturnValue('dark');
+
+    render(
+      <ThemeModeProvider initialMode="light">
+        <Probe />
+      </ThemeModeProvider>
+    );
+
+    expect(await screen.findByTestId('mode')).toHaveTextContent('dark');
+
+    await waitFor(() => {
+      expect(mockStoreDispatch).toHaveBeenCalled();
+    });
+
+    expect(mockSetPersistedThemeMode).toHaveBeenCalledWith('dark');
+    expect(mockPersistorSubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves system mode using matchMedia when no persisted mode exists', async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: true,
+        media: '(prefers-color-scheme: dark)',
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }),
+    });
+
+    try {
+      render(
+        <ThemeModeProvider initialMode="system">
+          <Probe />
+        </ThemeModeProvider>
+      );
+
+      expect(await screen.findByTestId('mode')).toHaveTextContent('dark');
+    } finally {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+});

--- a/apps/nhtfs/tests/unit/server/serverUseRelated.test.ts
+++ b/apps/nhtfs/tests/unit/server/serverUseRelated.test.ts
@@ -13,4 +13,10 @@ describe('server/serverUseRelated', () => {
       }),
     );
   });
+
+  it('returns deterministic fallback list when tags are missing or empty', () => {
+    expect(serverUseRelated()).toHaveLength(2);
+    expect(serverUseRelated([])).toHaveLength(2);
+    expect(serverUseRelated(['', 'nx', ''])).toHaveLength(2);
+  });
 });

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "packageManager": "pnpm@11.13.0",
   "scripts": {

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev -p 3999 --webpack",
     "build": "next build --webpack",
     "start": "next start",
+    "test": "node --test tests/**/*.test.mjs",
     "lint": "eslint",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/template/tests/smoke.test.mjs
+++ b/apps/template/tests/smoke.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('template app has expected runtime entrypoints', () => {
+  assert.equal(existsSync(path.join(appRoot, 'app', 'layout.tsx')), true);
+  assert.equal(existsSync(path.join(appRoot, 'next.config.ts')), true);
+  assert.equal(existsSync(path.join(appRoot, 'public')), true);
+});

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "3.0.1",
   "name": "www",
   "description": "NX°",
   "packageManager": "pnpm@11.13.0",

--- a/apps/www/tests/unit/api/index.test.ts
+++ b/apps/www/tests/unit/api/index.test.ts
@@ -1,0 +1,14 @@
+import { getBaseurl, getEndpoints, makeRes, makeTime } from '@/app/api';
+import { getBaseurl as getBaseurlLib } from '@/app/api/lib/getBaseurl';
+import { getEndpoints as getEndpointsLib } from '@/app/api/lib/getEndpoints';
+import { makeRes as makeResLib } from '@/app/api/lib/makeRes';
+import { makeTime as makeTimeLib } from '@/app/api/lib/makeTime';
+
+describe('api/index exports', () => {
+  it('re-exports API helpers from their source modules', () => {
+    expect(getBaseurl).toBe(getBaseurlLib);
+    expect(getEndpoints).toBe(getEndpointsLib);
+    expect(makeRes).toBe(makeResLib);
+    expect(makeTime).toBe(makeTimeLib);
+  });
+});

--- a/apps/www/tests/unit/designsystem/themeModeContext.test.tsx
+++ b/apps/www/tests/unit/designsystem/themeModeContext.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+const mockReadPersistedThemeModeFromStorage = jest.fn();
+const mockSetPersistedThemeMode = jest.fn((mode: 'light' | 'dark') => ({ type: 'theme/setPersistedThemeMode', payload: mode }));
+const mockStoreDispatch = jest.fn();
+const mockStoreGetState = jest.fn(() => ({}));
+const mockPersistorSubscribe = jest.fn(() => jest.fn());
+const mockPersistorGetState = jest.fn(() => ({ bootstrapped: false }));
+const mockSelectPersistedThemeMode = jest.fn(() => null);
+
+jest.mock('@nx/design-system', () => ({
+  DesignSystemProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@nx/uberedux', () => ({
+  readPersistedThemeModeFromStorage: () => mockReadPersistedThemeModeFromStorage(),
+  selectPersistedThemeMode: (...args: unknown[]) => mockSelectPersistedThemeMode(...args),
+  setPersistedThemeMode: (mode: 'light' | 'dark') => mockSetPersistedThemeMode(mode),
+  themePreferencePersistor: {
+    subscribe: (...args: unknown[]) => mockPersistorSubscribe(...args),
+    getState: (...args: unknown[]) => mockPersistorGetState(...args),
+  },
+  themePreferenceStore: {
+    dispatch: (...args: unknown[]) => mockStoreDispatch(...args),
+    getState: (...args: unknown[]) => mockStoreGetState(...args),
+  },
+}));
+
+import { ThemeModeProvider, resolveThemeMode, useThemeMode } from '@/app/NX/DesignSystem/ThemeModeContext';
+
+function Probe() {
+  const { mode } = useThemeMode();
+  return <span data-testid="mode">{mode}</span>;
+}
+
+describe('ThemeModeContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReadPersistedThemeModeFromStorage.mockReturnValue(null);
+    mockSelectPersistedThemeMode.mockReturnValue(null);
+  });
+
+  it('resolveThemeMode handles explicit and fallback modes', () => {
+    expect(resolveThemeMode('dark')).toBe('dark');
+    expect(resolveThemeMode('light')).toBe('light');
+    expect(resolveThemeMode('system')).toBe('light');
+    expect(resolveThemeMode(undefined)).toBe('light');
+  });
+
+  it('throws when useThemeMode is called outside provider', () => {
+    expect(() => render(<Probe />)).toThrow('useThemeMode must be used within a ThemeModeProvider');
+  });
+
+  it('applies persisted mode and dispatches persisted theme updates', async () => {
+    mockReadPersistedThemeModeFromStorage.mockReturnValue('dark');
+
+    render(
+      <ThemeModeProvider initialMode="light">
+        <Probe />
+      </ThemeModeProvider>
+    );
+
+    expect(await screen.findByTestId('mode')).toHaveTextContent('dark');
+
+    await waitFor(() => {
+      expect(mockStoreDispatch).toHaveBeenCalled();
+    });
+
+    expect(mockSetPersistedThemeMode).toHaveBeenCalledWith('dark');
+    expect(mockPersistorSubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves system mode using matchMedia when no persisted mode exists', async () => {
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: jest.fn().mockReturnValue({
+        matches: true,
+        media: '(prefers-color-scheme: dark)',
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }),
+    });
+
+    try {
+      render(
+        <ThemeModeProvider initialMode="system">
+          <Probe />
+        </ThemeModeProvider>
+      );
+
+      expect(await screen.findByTestId('mode')).toHaveTextContent('dark');
+    } finally {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
+  });
+});

--- a/apps/www/tests/unit/server/serverUseRelated.test.ts
+++ b/apps/www/tests/unit/server/serverUseRelated.test.ts
@@ -13,4 +13,10 @@ describe('server/serverUseRelated', () => {
       }),
     );
   });
+
+  it('returns deterministic fallback list when tags are missing or empty', () => {
+    expect(serverUseRelated()).toHaveLength(2);
+    expect(serverUseRelated([])).toHaveLength(2);
+    expect(serverUseRelated(['', 'nx', ''])).toHaveLength(2);
+  });
 });

--- a/docs/apps-packages.md
+++ b/docs/apps-packages.md
@@ -23,7 +23,7 @@ In this repository, the main app is located under [apps/nx](../apps/nx), and it 
 ## Packages
 Packages are reusable building blocks shared across apps or internal tooling. They are typically smaller, focused modules that can be imported by multiple parts of the monorepo.
 
-Examples in this repository include shared libraries under [packages](../packages), such as the Firebase and Flash packages.
+Examples in this repository include shared libraries under [packages](../packages), such as the Firebase, Flash, and Shortcodes packages.
 
 ## How to think about them
 - Use apps for product experiences and deployment targets.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -31,6 +31,7 @@ A Turborepo-managed monorepo with multiple Next.js applications and shared packa
 - `apps/www` -> the public product experience
 - `apps/admin` -> admin and operational tooling
 - `packages/design-system` -> reusable UI, tokens, and component primitives
+- `packages/shortcodes` -> markdown shortcode parsing and rendering helpers
 - `packages/uberedux` -> shared state and provider patterns
 - `packages/flash` -> presentation and runtime helpers
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -174,6 +174,7 @@ In short: we do not just "have tests". We have a testing system that protects de
 From repo root:
 
 - `pnpm test` runs the full monorepo testing pipeline
+- `pnpm test:coverage` runs merged monorepo coverage across Jest, Vitest, and Node/TSX suites
 - `pnpm --dir apps/www test` runs public app tests only
 - `pnpm --dir apps/nhtfs test` runs nhtfs app tests only
 - `pnpm --dir packages/design-system test` runs design-system tests only

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "clean": "bash ./shell/clean-repo.sh",
     "lint": "turbo run lint",
     "test": "node ./tests/run-monorepo-tests.mjs",
+    "test:coverage": "node ./tests/run-monorepo-coverage.mjs",
     "type-check": "turbo run type-check",
     "ci:github": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && corepack pnpm build-storybook && NEXT_TELEMETRY_DISABLED=1 corepack pnpm build",
     "ci:full": "corepack enable && corepack prepare pnpm@11.13.0 --activate && corepack pnpm install --frozen-lockfile && corepack pnpm lint && corepack pnpm type-check && corepack pnpm test && corepack pnpm build-storybook && corepack pnpm build"
   },
   "devDependencies": {
+    "c8": "^10.1.3",
     "concurrently": "^9.0.1",
     "turbo": "2.10.7"
   }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/design-system",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared frontend presentation package for NX°, covering theme, layout, and reusable UI primitives.",
   "private": true,
   "sideEffects": [

--- a/packages/design-system/tests/components/feedback/card-standalone.test.tsx
+++ b/packages/design-system/tests/components/feedback/card-standalone.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Card from '../../../src/components/feedback/Card';
+
+describe('feedback/Card standalone', () => {
+  it('renders with default paper styling and children', () => {
+    const { container } = render(<Card>Standalone card</Card>);
+
+    expect(screen.getByText('Standalone card')).toBeTruthy();
+
+    const card = container.firstElementChild as HTMLElement;
+    expect(getComputedStyle(card).paddingTop).toBe('24px');
+  });
+
+  it('supports hoverLift transitions and alternate variants', () => {
+    const { container, rerender } = render(
+      <Card variant="glass" hoverLift>
+        Hover card
+      </Card>
+    );
+
+    const card = container.firstElementChild as HTMLElement;
+    fireEvent.mouseEnter(card);
+    expect(getComputedStyle(card).transform).not.toBe('none');
+
+    fireEvent.mouseLeave(card);
+
+    rerender(
+      <Card variant="tile" padding="sm">
+        Tile card
+      </Card>
+    );
+
+    expect(screen.getByText('Tile card')).toBeTruthy();
+    expect(getComputedStyle(container.firstElementChild as HTMLElement).paddingTop).toBe('16px');
+
+    rerender(
+      <Card variant="ink" padding="lg">
+        Ink card
+      </Card>
+    );
+
+    expect(screen.getByText('Ink card')).toBeTruthy();
+    expect(getComputedStyle(container.firstElementChild as HTMLElement).paddingTop).toBe('32px');
+  });
+});

--- a/packages/design-system/tests/components/icons/svg-icons.test.tsx
+++ b/packages/design-system/tests/components/icons/svg-icons.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Icon } from '../../../src/components/icons';
+import BlokeyIcon from '../../../src/components/icons/SVGIcons/BlokeyIcon';
+import ChromeIcon from '../../../src/components/icons/SVGIcons/ChromeIcon';
+import DesktopIcon from '../../../src/components/icons/SVGIcons/DesktopIcon';
+import EdgeIcon from '../../../src/components/icons/SVGIcons/EdgeIcon';
+import FallmanagerIcon from '../../../src/components/icons/SVGIcons/FallmanagerIcon';
+import FirefoxIcon from '../../../src/components/icons/SVGIcons/FirefoxIcon';
+import FlickrIcon from '../../../src/components/icons/SVGIcons/FlickrIcon';
+import GatsbyIcon from '../../../src/components/icons/SVGIcons/GatsbyIcon';
+import GoldenticketIcon from '../../../src/components/icons/SVGIcons/GoldenticketIcon';
+import GoldlabelOutlined from '../../../src/components/icons/SVGIcons/GoldlabelOutlined';
+import GraphqlIcon from '../../../src/components/icons/SVGIcons/GraphqlIcon';
+import IphoneIcon from '../../../src/components/icons/SVGIcons/IphoneIcon';
+import LinuxIcon from '../../../src/components/icons/SVGIcons/LinuxIcon';
+import MacIcon from '../../../src/components/icons/SVGIcons/MacIcon';
+import MacromediaIcon from '../../../src/components/icons/SVGIcons/MacromediaIcon';
+import OliverIcon from '../../../src/components/icons/SVGIcons/OliverIcon';
+import OpenAIIcon from '../../../src/components/icons/SVGIcons/OpenAIIcon';
+import PingpongballIcon from '../../../src/components/icons/SVGIcons/PingpongballIcon';
+import SafariIcon from '../../../src/components/icons/SVGIcons/SafariIcon';
+import WindowsIcon from '../../../src/components/icons/SVGIcons/WindowsIcon';
+import WordpressIcon from '../../../src/components/icons/SVGIcons/WordpressIcon';
+import XboxIcon from '../../../src/components/icons/SVGIcons/XboxIcon';
+
+describe('svg icon components', () => {
+  it('exports Icon from icon barrel and renders known and unknown names', () => {
+    const known = render(<Icon icon="wordpress" />);
+    expect(known.container.querySelector('svg')).toBeTruthy();
+
+    const unknown = render(<Icon icon={'__unknown__'} />);
+    expect(unknown.container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('renders every standalone SVG icon component', () => {
+    const icons = [
+      BlokeyIcon,
+      ChromeIcon,
+      DesktopIcon,
+      EdgeIcon,
+      FallmanagerIcon,
+      FirefoxIcon,
+      FlickrIcon,
+      GatsbyIcon,
+      GoldenticketIcon,
+      GoldlabelOutlined,
+      GraphqlIcon,
+      IphoneIcon,
+      LinuxIcon,
+      MacIcon,
+      MacromediaIcon,
+      OliverIcon,
+      OpenAIIcon,
+      PingpongballIcon,
+      SafariIcon,
+      WindowsIcon,
+      WordpressIcon,
+      XboxIcon,
+    ];
+
+    for (const SvgComp of icons) {
+      const { container, unmount } = render(<SvgComp />);
+      expect(container.querySelector('svg')).toBeTruthy();
+      unmount();
+    }
+  });
+});

--- a/packages/design-system/tests/components/navigation/navigation.test.tsx
+++ b/packages/design-system/tests/components/navigation/navigation.test.tsx
@@ -71,6 +71,7 @@ describe('site navigation', () => {
   });
 
   it('renders share actions and copies the provided url', async () => {
+    const originalClipboard = navigator.clipboard;
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, {
       clipboard: {
@@ -78,25 +79,32 @@ describe('site navigation', () => {
       },
     });
 
-    render(
-      <Share
-        url="https://nx.dev/design-system/share"
-        title="NX Design System"
-        description="Reusable navigation primitives."
-      />
-    );
+    try {
+      const { unmount } = render(
+        <Share
+          url="https://nx.dev/design-system/share"
+          title="NX Design System"
+          description="Reusable navigation primitives."
+        />
+      );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open share menu' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Open share menu' }));
 
-    expect(await screen.findByRole('menu', { name: 'Share menu' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Share on X/Twitter' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Share on Facebook' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Share on LinkedIn' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Share on WhatsApp' })).toBeTruthy();
+      expect(await screen.findByRole('menu', { name: 'Share menu' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Share on X/Twitter' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Share on Facebook' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Share on LinkedIn' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Share on WhatsApp' })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
 
-    expect(writeText).toHaveBeenCalledWith('https://nx.dev/design-system/share');
-    expect((await screen.findByRole('status')).textContent).toContain('Copied https://nx.dev/design-system/share to clipboard.');
+      expect(writeText).toHaveBeenCalledWith('https://nx.dev/design-system/share');
+      expect((await screen.findByRole('status')).textContent).toContain('Copied https://nx.dev/design-system/share to clipboard.');
+
+      // Unmount to trigger Share cleanup and clear pending timeout callbacks.
+      unmount();
+    } finally {
+      Object.assign(navigator, { clipboard: originalClipboard });
+    }
   });
 });

--- a/packages/design-system/tests/components/surfaces/surfaces.test.tsx
+++ b/packages/design-system/tests/components/surfaces/surfaces.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Swatch from '../../../src/components/surfaces/Swatch';
+import SwatchGroup from '../../../src/components/surfaces/SwatchGroup';
+
+describe('surface swatches', () => {
+  it('renders a swatch and falls back to transparent when value is blank', () => {
+    const { container, rerender } = render(<Swatch label="Primary" value="#123456" />);
+
+    expect(screen.getByText('Primary')).toBeTruthy();
+    expect(screen.getByText('#123456')).toBeTruthy();
+
+    rerender(<Swatch label="Unset" value="   " />);
+    expect(screen.getByText('Unset')).toBeTruthy();
+
+    const valueCaption = container.querySelector('span') as HTMLElement;
+    expect(valueCaption.textContent).toBe('   ');
+
+    const colorBox = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(colorBox).toBeTruthy();
+    expect(getComputedStyle(colorBox).backgroundColor).toMatch(/transparent|rgba\(0, 0, 0, 0\)/);
+  });
+
+  it('renders a swatch group from a list of items', () => {
+    render(
+      <SwatchGroup
+        items={[
+          { label: 'Primary', value: '#111111' },
+          { label: 'Secondary', value: '#222222' },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Primary')).toBeTruthy();
+    expect(screen.getByText('Secondary')).toBeTruthy();
+  });
+});

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/nx-firebase",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/packages/flash/package-lock.json
+++ b/packages/flash/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nx/flash",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nx/flash",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "devDependencies": {
         "@types/react": "^19",
         "@types/react-dom": "^19",

--- a/packages/flash/package.json
+++ b/packages/flash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/flash",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "NX Flash: Macromedia Flash-inspired stage and MovieClip component system",
   "private": true,
   "main": "./src/index.ts",

--- a/packages/shortcodes/README.md
+++ b/packages/shortcodes/README.md
@@ -1,0 +1,33 @@
+# @nx/shortcodes
+
+WordPress-style shortcode parsing utilities for markdown-driven content.
+
+## Why this package exists
+
+Shortcodes let content editors embed dynamic features in markdown without writing React code directly.
+
+Example:
+
+```txt
+[CleverText text="How Shortcodes Work"]
+```
+
+This package provides reusable parsing primitives so apps can map shortcode tags to UI components.
+
+## API
+
+- `parseShortcodeAttributes(input)`
+- `findInlineShortcodes(input)`
+- `findBlockShortcodes(input)`
+- `tokenizeShortcodes(input)`
+- `renderShortcodes(input, resolvers, fallback?)`
+
+## Example
+
+```ts
+import { renderShortcodes } from '@nx/shortcodes';
+
+const output = renderShortcodes('Hi [CleverText text="World"]', {
+  CleverText: (match) => `<CleverText text="${String(match.attrs.text)}" />`,
+});
+```

--- a/packages/shortcodes/package.json
+++ b/packages/shortcodes/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nx/shortcodes",
+  "version": "3.0.0",
+  "description": "WordPress-style shortcode parsing utilities for markdown-driven NX content.",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "tsx --test tests/**/*.test.ts",
+    "type-check": "tsc --noEmit",
+    "lint": "echo 'No lint configured yet'"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5"
+  }
+}

--- a/packages/shortcodes/package.json
+++ b/packages/shortcodes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/shortcodes",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "WordPress-style shortcode parsing utilities for markdown-driven NX content.",
   "private": true,
   "main": "./src/index.ts",

--- a/packages/shortcodes/src/index.ts
+++ b/packages/shortcodes/src/index.ts
@@ -1,0 +1,19 @@
+export {
+  findBlockShortcodes,
+  findInlineShortcodes,
+  parseShortcodeAttributes,
+  renderShortcodes,
+  tokenizeShortcodes,
+} from './parser';
+
+export type {
+  ShortcodeAttributes,
+  ShortcodeBlockMatch,
+  ShortcodeMatch,
+  ShortcodeNode,
+  ShortcodeResolver,
+  ShortcodeResolverMap,
+  ShortcodeScalar,
+  ShortcodeTextNode,
+  ShortcodeToken,
+} from './types';

--- a/packages/shortcodes/src/parser.ts
+++ b/packages/shortcodes/src/parser.ts
@@ -1,0 +1,132 @@
+import {
+  type ShortcodeAttributes,
+  type ShortcodeBlockMatch,
+  type ShortcodeMatch,
+  type ShortcodeResolverMap,
+  type ShortcodeToken,
+} from './types';
+
+const INLINE_SHORTCODE_RE = /\[(?!\/)([A-Za-z][\w-]*)([^\]]*)\]/g;
+const BLOCK_SHORTCODE_RE = /\[(?!\/)([A-Za-z][\w-]*)([^\]]*)\]([\s\S]*?)\[\/\1\]/g;
+const ATTR_RE = /([A-Za-z][\w-]*)="([^"]*)"/g;
+
+function coerceAttributeValue(rawValue: string): string | number | boolean {
+  if (rawValue === 'true') return true;
+  if (rawValue === 'false') return false;
+
+  if (/^-?\d+(\.\d+)?$/.test(rawValue)) {
+    const parsed = Number(rawValue);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+
+  return rawValue;
+}
+
+export function parseShortcodeAttributes(input: string): ShortcodeAttributes {
+  const attrs: ShortcodeAttributes = {};
+
+  for (const match of input.matchAll(ATTR_RE)) {
+    const key = match[1];
+    const rawValue = match[2] ?? '';
+    attrs[key] = coerceAttributeValue(rawValue);
+  }
+
+  return attrs;
+}
+
+export function findInlineShortcodes(input: string): ShortcodeMatch[] {
+  const matches: ShortcodeMatch[] = [];
+
+  for (const match of input.matchAll(INLINE_SHORTCODE_RE)) {
+    const [raw, name, attrChunk = ''] = match;
+    matches.push({
+      name,
+      attrs: parseShortcodeAttributes(attrChunk),
+      raw,
+      index: match.index ?? 0,
+    });
+  }
+
+  return matches;
+}
+
+export function findBlockShortcodes(input: string): ShortcodeBlockMatch[] {
+  const matches: ShortcodeBlockMatch[] = [];
+
+  for (const match of input.matchAll(BLOCK_SHORTCODE_RE)) {
+    const [raw, name, attrChunk = '', content = ''] = match;
+    matches.push({
+      name,
+      attrs: parseShortcodeAttributes(attrChunk),
+      content,
+      raw,
+      index: match.index ?? 0,
+    });
+  }
+
+  return matches;
+}
+
+export function tokenizeShortcodes(input: string): ShortcodeToken[] {
+  const tokens: ShortcodeToken[] = [];
+  let cursor = 0;
+
+  for (const match of input.matchAll(INLINE_SHORTCODE_RE)) {
+    const start = match.index ?? 0;
+    const raw = match[0] ?? '';
+    const end = start + raw.length;
+
+    if (start > cursor) {
+      tokens.push({
+        type: 'text',
+        value: input.slice(cursor, start),
+      });
+    }
+
+    tokens.push({
+      type: 'shortcode',
+      value: {
+        name: match[1],
+        attrs: parseShortcodeAttributes(match[2] ?? ''),
+        raw,
+        index: start,
+      },
+    });
+
+    cursor = end;
+  }
+
+  if (cursor < input.length) {
+    tokens.push({
+      type: 'text',
+      value: input.slice(cursor),
+    });
+  }
+
+  return tokens;
+}
+
+export function renderShortcodes<T>(
+  input: string,
+  resolvers: ShortcodeResolverMap<T>,
+  fallback: (match: ShortcodeMatch) => T | string = (match) => match.raw,
+): Array<string | T> {
+  const rendered: Array<string | T> = [];
+
+  for (const token of tokenizeShortcodes(input)) {
+    if (token.type === 'text') {
+      rendered.push(token.value);
+      continue;
+    }
+
+    const resolver = resolvers[token.value.name];
+    if (resolver) {
+      rendered.push(resolver(token.value));
+      continue;
+    }
+
+    rendered.push(fallback(token.value));
+  }
+
+  return rendered;
+}

--- a/packages/shortcodes/src/types.ts
+++ b/packages/shortcodes/src/types.ts
@@ -1,0 +1,30 @@
+export type ShortcodeScalar = string | number | boolean;
+
+export type ShortcodeAttributes = Record<string, ShortcodeScalar>;
+
+export interface ShortcodeMatch {
+  name: string;
+  attrs: ShortcodeAttributes;
+  raw: string;
+  index: number;
+}
+
+export interface ShortcodeBlockMatch extends ShortcodeMatch {
+  content: string;
+}
+
+export interface ShortcodeTextNode {
+  type: 'text';
+  value: string;
+}
+
+export interface ShortcodeNode {
+  type: 'shortcode';
+  value: ShortcodeMatch;
+}
+
+export type ShortcodeToken = ShortcodeTextNode | ShortcodeNode;
+
+export type ShortcodeResolver<T> = (match: ShortcodeMatch) => T;
+
+export type ShortcodeResolverMap<T> = Record<string, ShortcodeResolver<T>>;

--- a/packages/shortcodes/tests/parser.test.ts
+++ b/packages/shortcodes/tests/parser.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  findBlockShortcodes,
+  findInlineShortcodes,
+  parseShortcodeAttributes,
+  renderShortcodes,
+  tokenizeShortcodes,
+} from '../src/index';
+
+test('parseShortcodeAttributes parses scalars and coercions', () => {
+  const attrs = parseShortcodeAttributes(' text="Hello" enabled="true" count="3" ratio="1.5" ');
+
+  assert.equal(attrs.text, 'Hello');
+  assert.equal(attrs.enabled, true);
+  assert.equal(attrs.count, 3);
+  assert.equal(attrs.ratio, 1.5);
+});
+
+test('findInlineShortcodes extracts shortcode metadata', () => {
+  const markdown = 'Start [CleverText text="Installable on any phone"] end';
+  const matches = findInlineShortcodes(markdown);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].name, 'CleverText');
+  assert.equal(matches[0].attrs.text, 'Installable on any phone');
+  assert.equal(matches[0].raw, '[CleverText text="Installable on any phone"]');
+});
+
+test('findBlockShortcodes parses paired shortcode content', () => {
+  const markdown = '[alert type="warning"]Watch this space[/alert]';
+  const matches = findBlockShortcodes(markdown);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].name, 'alert');
+  assert.equal(matches[0].attrs.type, 'warning');
+  assert.equal(matches[0].content, 'Watch this space');
+});
+
+test('tokenizeShortcodes keeps text and shortcode sequence', () => {
+  const markdown = 'A [PageLink url="/features/shortcodes" label="Learn"] B';
+  const tokens = tokenizeShortcodes(markdown);
+
+  assert.equal(tokens.length, 3);
+  assert.equal(tokens[0].type, 'text');
+  assert.equal(tokens[1].type, 'shortcode');
+  assert.equal(tokens[2].type, 'text');
+
+  if (tokens[1].type === 'shortcode') {
+    assert.equal(tokens[1].value.name, 'PageLink');
+    assert.equal(tokens[1].value.attrs.url, '/features/shortcodes');
+  }
+});
+
+test('renderShortcodes maps shortcode names to renderers with fallback', () => {
+  const markdown = 'Intro [CleverText text="How Shortcodes Work"] tail [Unknown foo="bar"]';
+  const rendered = renderShortcodes(markdown, {
+    CleverText: (match) => `<CleverText text="${String(match.attrs.text)}" />`,
+  });
+
+  assert.deepEqual(rendered, [
+    'Intro ',
+    '<CleverText text="How Shortcodes Work" />',
+    ' tail ',
+    '[Unknown foo="bar"]',
+  ]);
+});

--- a/packages/shortcodes/tsconfig.json
+++ b/packages/shortcodes/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/uberedux/package.json
+++ b/packages/uberedux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/uberedux",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared Redux store/provider/hooks used across NX apps.",
   "private": true,
   "main": "./src/index.ts",

--- a/packages/virus/package.json
+++ b/packages/virus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/virus",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Fingerprint identity and Firestore live-profile utilities for individualized client experiences.",
   "private": true,
   "main": "./src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      c8:
+        specifier: ^10.1.3
+        version: 10.1.3
       concurrently:
         specifier: ^9.0.1
         version: 9.2.4
@@ -4584,6 +4587,16 @@ packages:
 
   bytewise@1.1.0:
     resolution: {integrity: sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==}
+
+  c8@10.1.3:
+    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -13606,6 +13619,20 @@ snapshots:
     dependencies:
       bytewise-core: 1.2.3
       typewise: 1.0.3
+
+  c8@10.1.3:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 7.0.2
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.3
+      yargs-parser: 21.1.1
 
   cac@6.7.14: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,15 @@ importers:
         specifier: ^7.1.2
         version: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
+  packages/shortcodes:
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.1
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   packages/uberedux:
     dependencies:
       '@reduxjs/toolkit':

--- a/tests/run-monorepo-coverage.mjs
+++ b/tests/run-monorepo-coverage.mjs
@@ -1,0 +1,354 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const supportsColor = Boolean(process.stdout.isTTY) && !('NO_COLOR' in process.env) && process.env.TERM !== 'dumb';
+
+const color = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  cyan: '\x1b[36m',
+  blue: '\x1b[34m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  magenta: '\x1b[35m',
+};
+
+const paint = (code, text) => (supportsColor ? `${code}${text}${color.reset}` : text);
+
+const run = (command, args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      env: {
+        ...process.env,
+        FORCE_COLOR: supportsColor ? '1' : '0',
+      },
+    });
+
+    child.on('error', (error) => reject(error));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${command} ${args.join(' ')} exited with code ${code ?? 1}`));
+        return;
+      }
+      resolve();
+    });
+  });
+
+const repoRoot = process.cwd();
+const coverageRoot = path.join(repoRoot, 'coverage');
+
+function resetCoverageDir() {
+  fs.rmSync(coverageRoot, { recursive: true, force: true });
+  fs.mkdirSync(coverageRoot, { recursive: true });
+}
+
+function readSummary(summaryPath) {
+  if (!fs.existsSync(summaryPath)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+}
+
+function mergeTotals(target, sourceTotal) {
+  for (const key of ['lines', 'statements', 'functions', 'branches']) {
+    target[key].total += sourceTotal[key]?.total ?? 0;
+    target[key].covered += sourceTotal[key]?.covered ?? 0;
+    target[key].skipped += sourceTotal[key]?.skipped ?? 0;
+  }
+}
+
+function summarizeTotals(totals) {
+  const result = {};
+  for (const key of ['lines', 'statements', 'functions', 'branches']) {
+    const total = totals[key].total;
+    const covered = totals[key].covered;
+    result[key] = {
+      total,
+      covered,
+      skipped: totals[key].skipped,
+      pct: total === 0 ? 100 : Number(((covered / total) * 100).toFixed(1)),
+    };
+  }
+  return result;
+}
+
+function gatherLowCoverageFiles(summary, sourceName, threshold = 100) {
+  const files = [];
+
+  for (const [filePath, metrics] of Object.entries(summary)) {
+    if (filePath === 'total') continue;
+
+    const linePct = Number(metrics?.lines?.pct ?? 0);
+    if (linePct < threshold) {
+      files.push({
+        source: sourceName,
+        filePath,
+        linesPct: linePct,
+        branchesPct: Number(metrics?.branches?.pct ?? 0),
+        functionsPct: Number(metrics?.functions?.pct ?? 0),
+      });
+    }
+  }
+
+  return files;
+}
+
+const runs = [
+  {
+    name: 'apps-www-jest',
+    command: 'pnpm',
+    args: [
+      '--dir',
+      'apps/www',
+      'exec',
+      'jest',
+      '--runInBand',
+      '--passWithNoTests',
+      '--coverage',
+      '--coverageReporters=json-summary',
+      '--coverageReporters=text',
+      '--coverageDirectory=../../coverage/apps-www-jest',
+    ],
+    summaryPath: path.join(coverageRoot, 'apps-www-jest', 'coverage-summary.json'),
+  },
+  {
+    name: 'apps-nhtfs-jest',
+    command: 'pnpm',
+    args: [
+      '--dir',
+      'apps/nhtfs',
+      'exec',
+      'jest',
+      '--runInBand',
+      '--passWithNoTests',
+      '--coverage',
+      '--coverageReporters=json-summary',
+      '--coverageReporters=text',
+      '--coverageDirectory=../../coverage/apps-nhtfs-jest',
+    ],
+    summaryPath: path.join(coverageRoot, 'apps-nhtfs-jest', 'coverage-summary.json'),
+  },
+  {
+    name: 'packages-design-system-vitest',
+    command: 'pnpm',
+    args: [
+      '--dir',
+      'packages/design-system',
+      'exec',
+      'vitest',
+      'run',
+      '--coverage',
+      '--coverage.reporter=json-summary',
+      '--coverage.reporter=text',
+      '--coverage.reportsDirectory=../../coverage/packages-design-system-vitest',
+    ],
+    summaryPath: path.join(coverageRoot, 'packages-design-system-vitest', 'coverage-summary.json'),
+  },
+  {
+    name: 'packages-firebase-node',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/packages-firebase-node',
+      'node',
+      '--test',
+      'packages/firebase/tests/**/*.test.js',
+    ],
+    summaryPath: path.join(coverageRoot, 'packages-firebase-node', 'coverage-summary.json'),
+  },
+  {
+    name: 'packages-flash-tsx',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/packages-flash-tsx',
+      'tsx',
+      '--test',
+      'packages/flash/tests/**/*.test.ts',
+    ],
+    summaryPath: path.join(coverageRoot, 'packages-flash-tsx', 'coverage-summary.json'),
+  },
+  {
+    name: 'packages-uberedux-tsx',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/packages-uberedux-tsx',
+      'tsx',
+      '--test',
+      'packages/uberedux/tests/**/*.test.ts',
+    ],
+    summaryPath: path.join(coverageRoot, 'packages-uberedux-tsx', 'coverage-summary.json'),
+  },
+  {
+    name: 'packages-virus-tsx',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/packages-virus-tsx',
+      'tsx',
+      '--test',
+      'packages/virus/tests/**/*.test.ts',
+    ],
+    summaryPath: path.join(coverageRoot, 'packages-virus-tsx', 'coverage-summary.json'),
+  },
+  {
+    name: 'packages-shortcodes-tsx',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/packages-shortcodes-tsx',
+      'tsx',
+      '--test',
+      'packages/shortcodes/tests/**/*.test.ts',
+    ],
+    summaryPath: path.join(coverageRoot, 'packages-shortcodes-tsx', 'coverage-summary.json'),
+  },
+  {
+    name: 'apps-admin-node',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/apps-admin-node',
+      'node',
+      '--test',
+      'apps/admin/tests/**/*.test.mjs',
+    ],
+    summaryPath: path.join(coverageRoot, 'apps-admin-node', 'coverage-summary.json'),
+  },
+  {
+    name: 'apps-template-node',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/apps-template-node',
+      'node',
+      '--test',
+      'apps/template/tests/**/*.test.mjs',
+    ],
+    summaryPath: path.join(coverageRoot, 'apps-template-node', 'coverage-summary.json'),
+  },
+  {
+    name: 'root-tests-node',
+    command: 'pnpm',
+    args: [
+      'exec',
+      'c8',
+      '--reporter=json-summary',
+      '--reporter=text',
+      '--report-dir',
+      'coverage/root-tests-node',
+      'node',
+      '--test',
+      'tests/*.test.mjs',
+    ],
+    summaryPath: path.join(coverageRoot, 'root-tests-node', 'coverage-summary.json'),
+  },
+];
+
+resetCoverageDir();
+
+for (const runConfig of runs) {
+  console.log(`\n${paint(color.bold, paint(color.cyan, `Running coverage: ${runConfig.name}`))}`);
+  await run(runConfig.command, runConfig.args);
+}
+
+const aggregateTotals = {
+  lines: { total: 0, covered: 0, skipped: 0 },
+  statements: { total: 0, covered: 0, skipped: 0 },
+  functions: { total: 0, covered: 0, skipped: 0 },
+  branches: { total: 0, covered: 0, skipped: 0 },
+};
+
+const coverageSources = [];
+let underCoveredFiles = [];
+
+for (const runConfig of runs) {
+  const summary = readSummary(runConfig.summaryPath);
+  if (!summary?.total) continue;
+
+  mergeTotals(aggregateTotals, summary.total);
+  coverageSources.push({
+    name: runConfig.name,
+    summaryPath: runConfig.summaryPath,
+    totals: summary.total,
+  });
+
+  underCoveredFiles = underCoveredFiles.concat(gatherLowCoverageFiles(summary, runConfig.name, 100));
+}
+
+underCoveredFiles.sort((a, b) => a.linesPct - b.linesPct || a.filePath.localeCompare(b.filePath));
+
+const aggregate = summarizeTotals(aggregateTotals);
+const aggregatePath = path.join(coverageRoot, 'coverage-aggregate.json');
+
+fs.writeFileSync(
+  aggregatePath,
+  JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      totals: aggregate,
+      sourceCount: coverageSources.length,
+      sources: coverageSources,
+      underCoveredFiles,
+    },
+    null,
+    2,
+  ),
+);
+
+const colorPct = (pct) => {
+  if (pct >= 90) return paint(color.green, `${pct.toFixed(1)}%`);
+  if (pct >= 70) return paint(color.yellow, `${pct.toFixed(1)}%`);
+  return paint(color.red, `${pct.toFixed(1)}%`);
+};
+
+console.log(`\n${paint(color.bold, paint(color.cyan, '=== Monorepo Coverage Overview ==='))}`);
+console.log(`${paint(color.blue, 'Sources merged:')} ${paint(color.bold, String(coverageSources.length))}`);
+console.log(`${paint(color.blue, 'Lines:')} ${colorPct(aggregate.lines.pct)} (${aggregate.lines.covered}/${aggregate.lines.total})`);
+console.log(`${paint(color.blue, 'Statements:')} ${colorPct(aggregate.statements.pct)} (${aggregate.statements.covered}/${aggregate.statements.total})`);
+console.log(`${paint(color.blue, 'Functions:')} ${colorPct(aggregate.functions.pct)} (${aggregate.functions.covered}/${aggregate.functions.total})`);
+console.log(`${paint(color.blue, 'Branches:')} ${colorPct(aggregate.branches.pct)} (${aggregate.branches.covered}/${aggregate.branches.total})`);
+console.log(`${paint(color.blue, 'Files below 100% line coverage:')} ${paint(color.bold, String(underCoveredFiles.length))}`);
+
+if (underCoveredFiles.length > 0) {
+  console.log(`\n${paint(color.bold, paint(color.magenta, 'Lowest-covered files:'))}`);
+  for (const file of underCoveredFiles.slice(0, 20)) {
+    console.log(`- ${file.linesPct.toFixed(1)}% lines | ${file.filePath} (${file.source})`);
+  }
+}
+
+console.log(`\n${paint(color.blue, 'Aggregate report:')} ${aggregatePath}`);

--- a/tests/run-monorepo-tests.mjs
+++ b/tests/run-monorepo-tests.mjs
@@ -114,10 +114,29 @@ try {
 }
 
 const combinedOutput = stripAnsi(`${recursiveOutput}\n${rootOutput}`);
-const jestTests = sumMatches(combinedOutput, /Tests:\s+\d+\s+passed,\s+(\d+)\s+total/g);
-const vitestTests = sumMatches(combinedOutput, /Tests\s+\d+\s+passed\s+\((\d+)\)/g);
-const nodeTests = sumMatches(combinedOutput, /(?:ℹ|i)\s*tests\s+(\d+)/gi);
-const totalTests = jestTests + vitestTests + nodeTests;
+const formatNumber = (value) => new Intl.NumberFormat('en-GB').format(value);
+
+const sumTwoMatches = (text, regex) => {
+  let passed = 0;
+  let total = 0;
+
+  for (const match of text.matchAll(regex)) {
+    passed += Number(match[1] ?? 0);
+    total += Number(match[2] ?? 0);
+  }
+
+  return { passed, total };
+};
+
+const jest = sumTwoMatches(combinedOutput, /Tests:\s+(\d+)\s+passed,\s+(\d+)\s+total/g);
+const vitest = sumTwoMatches(combinedOutput, /Tests\s+(\d+)\s+passed\s+\((\d+)\)/g);
+const node = {
+  passed: sumMatches(combinedOutput, /(?:ℹ|i)\s*pass\s+(\d+)/gi),
+  total: sumMatches(combinedOutput, /(?:ℹ|i)\s*tests\s+(\d+)/gi),
+};
+
+const totalPassed = jest.passed + vitest.passed + node.passed;
+const totalTests = jest.total + vitest.total + node.total;
 
 const workspaceCoverage =
   workspacePackageJsons.length === 0
@@ -129,9 +148,16 @@ const packageCoverage =
 
 clearTerminal();
 
-console.log(`\n${paint(color.bold, paint(color.cyan, '=== Proud Overview ==='))}`);
+console.log(`\n${paint(color.bold, paint(color.cyan, '=== NX° test suite ==='))}`);
+console.log('');
 console.log(
-  `${paint(color.blue, 'Total automated tests executed:')} ${paint(color.bold, paint(color.magenta, String(totalTests)))}`
+  `${paint(color.blue, 'Total tests passed:')} ${paint(color.bold, paint(color.magenta, formatNumber(totalPassed)))}`
+);
+console.log(
+  `${paint(color.blue, 'Total tests executed:')} ${paint(color.bold, formatNumber(totalTests))}`
+);
+console.log(
+  `${paint(color.blue, 'By test type:')} ${paint(color.bold, 'Jest')} ${formatNumber(jest.passed)}/${formatNumber(jest.total)} | ${paint(color.bold, 'Vitest')} ${formatNumber(vitest.passed)}/${formatNumber(vitest.total)} | ${paint(color.bold, 'Node/TSX')} ${formatNumber(node.passed)}/${formatNumber(node.total)}`
 );
 console.log(
   `${paint(color.blue, 'Workspace coverage:')} ${paint(color.bold, `${testedWorkspaces}/${workspacePackageJsons.length}`)} workspaces with test scripts (${paint(colorByPercent(workspaceCoverage), `${workspaceCoverage}%`)})`
@@ -139,4 +165,6 @@ console.log(
 console.log(
   `${paint(color.blue, 'App coverage:')} ${paint(color.bold, `${testedApps}/${appPackageJsons.length}`)} (${paint(colorByPercent(appCoverage), `${appCoverage}%`)}) | ${paint(color.blue, 'Package coverage:')} ${paint(color.bold, `${testedPackages}/${packagePackageJsons.length}`)} (${paint(colorByPercent(packageCoverage), `${packageCoverage}%`)})`
 );
-console.log(paint(color.bold, paint(color.green, 'Quality signal: full monorepo test pipeline passed.')));
+console.log('');
+console.log(paint(color.bold, paint(color.green, '✅ RESULT: full monorepo test suite passed.')));
+console.log('');

--- a/tests/testing-framework.test.mjs
+++ b/tests/testing-framework.test.mjs
@@ -17,6 +17,7 @@ test('critical workspaces define a test script', () => {
     'packages/design-system/package.json',
     'packages/firebase/package.json',
     'packages/flash/package.json',
+    'packages/shortcodes/package.json',
     'packages/uberedux/package.json',
     'packages/virus/package.json',
   ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,8 @@
       "@nx/ui/*": ["packages/ui/*"],
       "@nx/design-system": ["packages/design-system/src"],
       "@nx/design-system/*": ["packages/design-system/src/*"],
+      "@nx/shortcodes": ["packages/shortcodes/src"],
+      "@nx/shortcodes/*": ["packages/shortcodes/src/*"],
       "@nx/uberedux": ["packages/uberedux/src"],
       "@nx/uberedux/*": ["packages/uberedux/src/*"],
       "@nx/virus": ["packages/virus/src"],


### PR DESCRIPTION
This pull request introduces new and enhanced tests across multiple apps and packages, adds coverage tooling, and improves documentation for the testing and package structure. The main focus is on expanding test coverage for APIs, UI components, and theme context logic, as well as making the test and coverage workflow more robust and discoverable.

**Testing improvements and new coverage:**

* Added comprehensive unit tests for the `ThemeModeContext` logic in both `apps/nhtfs` and `apps/www`, including handling of persisted theme modes, system preference resolution, and provider usage errors.
* Added smoke tests for `apps/admin` and `apps/template` to verify the presence of key runtime entrypoints, improving confidence in app structure. [[1]](diffhunk://#diff-23cc135a83f6826803cbfc5554cbfe1c8321851ab57879cc36d0419c187d3515R1-R13) [[2]](diffhunk://#diff-ac3fcd98dc5c97ba292944626d1fb42f430723ab6c32b4b6371f5f003033b30dR1-R13)
* Introduced tests for API helper re-exports in both `apps/nhtfs` and `apps/www` to ensure correct module boundaries.
* Improved tests for the `serverUseRelated` logic in both `apps/nhtfs` and `apps/www` to assert fallback behavior when tags are missing or empty.
* Added new tests for UI components in `packages/design-system`, including standalone `Card` variants, all SVG icon components, and improved navigation/share action tests with cleanup and clipboard mocking. [[1]](diffhunk://#diff-b2c0f573841734f9fece7a6cd061805bc00b79ed89fe007b7610d7fb87e1fe30R1-R46) [[2]](diffhunk://#diff-b34190239e248cb5cd445fdfac46be03010f060a7fa206e542ad2602b1ba9cd1R1-R68) [[3]](diffhunk://#diff-2f868cd25cbde2aa2078a50a35061c2a5191c15259a2b57e92ed4b5d3b95cb37R74-R83) [[4]](diffhunk://#diff-2f868cd25cbde2aa2078a50a35061c2a5191c15259a2b57e92ed4b5d3b95cb37R103-R108)

**Testing infrastructure and scripts:**

* Added `test` scripts to `apps/admin/package.json` and `apps/template/package.json` to enable per-app test running with Node's test runner. [[1]](diffhunk://#diff-09446fbce2950f344fb4df3c46f5c9417abeccdbefecee1266c6762206108221R9) [[2]](diffhunk://#diff-5c65d2a3a2a60fe1414bc0163723a81394c37af577335ae3f44841653aab3d3dR10)
* Added a new `test:coverage` script at the root and included `c8` as a dev dependency to support merged coverage reporting across all test suites. ([package.jsonR17-R23](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17-R23), F2eba233L174R174)

**Documentation updates:**

* Updated developer docs to reflect the addition of the `shortcodes` package and improved descriptions of the package structure. [[1]](diffhunk://#diff-8e9c1354875e7b4eaf5b4056ea10b1a7aaa24176656ecbf9fe259dc4d1dadc1aR34) [[2]](diffhunk://#diff-4d07a2207b67f53720eead0d8709465e9cff5e5841649eed66eeef82b1fa9572L26-R26)
* Clarified testing strategy documentation to include the new coverage command and per-app test instructions.

These changes collectively enhance test coverage, reliability, and developer onboarding for the monorepo.