### PR TITLE
Remove About footer fallback columns

### DIFF
--- a/apps/nhtfs/app/[[...slug]]/page.tsx
+++ b/apps/nhtfs/app/[[...slug]]/page.tsx
@@ -105,7 +105,6 @@ export default async function Page({ params }: T_PageProps) {
     const footerColumns = getFooterColumnsFromChildPages(childPages, {
         maxColumns: 4,
         maxChildrenPerColumn: 1,
-        fallbackColumns: [{ title: 'About', href: '/about' }],
     });
     const breadcrumbItems = slugArr.length
         ? [

--- a/apps/template/app/lib/markdown.ts
+++ b/apps/template/app/lib/markdown.ts
@@ -173,6 +173,5 @@ export function getMarkdownFooterColumns(currentPath: string): FooterColumn[] {
   return getFooterColumnsFromChildPages(childPages, {
     maxColumns: 4,
     maxChildrenPerColumn: 1,
-    fallbackColumns: [{ title: 'About', href: '/about' }],
   });
 }

--- a/apps/www/app/[[...slug]]/page.tsx
+++ b/apps/www/app/[[...slug]]/page.tsx
@@ -104,7 +104,6 @@ export default async function Page({ params }: T_PageProps) {
     const footerColumns = getFooterColumnsFromChildPages(childPages, {
         maxColumns: 4,
         maxChildrenPerColumn: 1,
-        fallbackColumns: [{ title: 'About', href: '/about' }],
     });
     const breadcrumbItems = slugArr.length
         ? [


### PR DESCRIPTION
Dropped the hardcoded `fallbackColumns` (`About` link) from footer column generation in `nhtfs`, `www`, and template markdown helpers. Footer navigation now reflects only actual child page structure instead of injecting a default link.