### PR TITLE
Rename NHTFS site name

### DIFF
--- a/apps/nhtfs/public/nx/config.json
+++ b/apps/nhtfs/public/nx/config.json
@@ -1,6 +1,6 @@
 {
     "tenant": "nx",
-    "siteName": "NX°",
+    "siteName": "Nhtfs",
     "description": "Rapidly build modern apps",
     "url": "https://goldlabel.pro",
     "owner": {


### PR DESCRIPTION
Update the NX site config to use `Nhtfs` instead of `NX°` as the public site name.