### PR TITLE
Remove custom HTML headers from docs

### DIFF
--- a/apps/nhtfs/next-env.d.ts
+++ b/apps/nhtfs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/template/next-env.d.ts
+++ b/apps/template/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/www/public/nx/markdown/about/index.md
+++ b/apps/www/public/nx/markdown/about/index.md
@@ -18,7 +18,7 @@ UK Limited Company 5460545
 
 [GitHub](https://github.com/goldlabelapps) | [LinkedIn](https://www.linkedin.com/in/chris-dorward) | [Twitter, X](https://x.com/goldlabelapps) | [Insta](https://www.instagram.com/milkylackstoes) | [Facebook](https://www.facebook.com/goldlabelappss) | [Youtube](https://www.youtube.com/@milkylackstoes) | [Flickr](https://www.flickr.com/photos/listingslab)
 
-## Business Documentation
+#### Business Documentation
 
 - [Business overview](/docs/business)
 - [Executive overview](/docs/business/executive-overview)

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/index.md
@@ -7,6 +7,6 @@ icon: docs
 tags: docs
 ---
 
-## Admin Cartridges
+#### Admin Cartridges
 
 - [NX Admin cartridge](/docs/apps/admin/cartridges/nx-admin)

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/actions.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/actions.md
@@ -16,7 +16,7 @@ All actions are Redux thunks. They are exported from `app/NX/NXAdmin/index.tsx` 
 
 ---
 
-## `setNXAdmin(key, value)`
+#### `setNXAdmin(key, value)`
 
 The primary state setter for the Dashboard slice. Merges the given key-value pair into `state.redux.nxAdmin`.
 
@@ -41,7 +41,7 @@ The action reads the current `nxAdmin` object, spreads it, overwrites the given 
 
 ---
 
-## `setCRUD(collection, key, value)`
+#### `setCRUD(collection, key, value)`
 
 Updates a specific key within a collection's CRUD state at `state.redux.nxAdmin.crud[collection][key]`.
 
@@ -68,7 +68,7 @@ dispatch(setCRUD('products', 'saving', true));
 
 ---
 
-## `initCollection(collection, options?)`
+#### `initCollection(collection, options?)`
 
 Initialises a Firestore collection in the Redux CRUD slice and begins listening for real-time updates (or performs a one-time fetch).
 
@@ -125,7 +125,7 @@ When `subscribe: true`, the action returns the Firestore `unsubscribe` function.
 
 ---
 
-## `saveNewDoc(collection, data)`
+#### `saveNewDoc(collection, data)`
 
 Creates a new document in Firestore, then selects it and switches mode to `'update'`.
 
@@ -157,7 +157,7 @@ dispatch(saveNewDoc('products', {
 
 ---
 
-## `edit(collection, data)`
+#### `edit(collection, data)`
 
 Updates an existing Firestore document and refreshes local state.
 
@@ -171,7 +171,7 @@ dispatch(edit('products', { id: 'abc123', label: 'Updated Widget' }));
 
 ---
 
-## `collectionDelete(collection, id)`
+#### `collectionDelete(collection, id)`
 
 Deletes a Firestore document from a collection.
 
@@ -185,7 +185,7 @@ dispatch(collectionDelete('products', 'abc123'));
 
 ---
 
-## `readTypescript(collection)`
+#### `readTypescript(collection)`
 
 Reads the `typescript` schema document for a collection and stores it in the CRUD state.
 
@@ -199,7 +199,7 @@ dispatch(readTypescript('products'));
 
 ---
 
-## `subscribeUser(uid)`
+#### `subscribeUser(uid)`
 
 Subscribes to a user's Firestore document and keeps the Redux `paywall` slice in sync.
 
@@ -213,7 +213,7 @@ dispatch(subscribeUser(uid));
 
 ---
 
-## `requestNotifications()`
+#### `requestNotifications()`
 
 Requests browser notification permission, obtains an FCM registration token, and persists the token to the user's Firestore document.
 
@@ -236,7 +236,7 @@ dispatch(requestNotifications());
 
 ---
 
-## `pwaAlert()`
+#### `pwaAlert()`
 
 Initialises PWA install prompt detection. Should be called once on app mount.
 
@@ -252,7 +252,7 @@ See the [PWA Support](./pwa.md) document for full details.
 
 ---
 
-## `triggerPwaInstall()`
+#### `triggerPwaInstall()`
 
 Programmatically triggers the browser's native PWA install prompt.
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/actions.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/actions.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin/actions
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Actions</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin, actions

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/components.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/components.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin/components
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Components</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin, components

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/components.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/components.md
@@ -16,7 +16,7 @@ All components are exported from `app/NX/NXAdmin/index.tsx`.
 
 ---
 
-## Layout Components
+#### Layout Components
 
 ### `<NXAdmin>`
 
@@ -121,7 +121,7 @@ import { PageRouter } from '@/NX/NXAdmin';
 
 ---
 
-## Page Components
+#### Page Components
 
 ### `<MegaDash>`
 
@@ -243,7 +243,7 @@ import { Fingerprints } from '@/NX/NXAdmin';
 
 ---
 
-## CRUD Components
+#### CRUD Components
 
 See the [CRUD System](./crud.md) document for full details. The four components below are used internally by `<Collection>` but can also be used standalone.
 
@@ -298,7 +298,7 @@ import { DeleteDoc } from '@/NX/NXAdmin';
 
 ---
 
-## Menu Components
+#### Menu Components
 
 ### `<NXAdminMenu>`
 
@@ -377,7 +377,7 @@ Displays the current user's name, email, and avatar. Used inside `<NXAdminMenu>`
 
 ---
 
-## UI Primitives
+#### UI Primitives
 
 ### `<InputString>`
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/crud.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/crud.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin/crud
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Crud</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin, crud

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/crud.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/crud.md
@@ -16,13 +16,13 @@ The Dashboard CRUD system provides a zero-configuration, schema-driven way to ma
 
 ---
 
-## Overview
+#### Overview
 
 Each collection managed by Dashboard gets its own isolated state entry in `state.redux.nxAdmin.crud[collectionName]`. The system is driven by a **TypeScript schema document** — a special Firestore document named `typescript` within each collection — that describes the fields, their types, labels, and validation rules.
 
 ---
 
-## The TypeScript Schema Document
+#### The TypeScript Schema Document
 
 For each Firestore collection you want to manage, create a document with the ID `typescript`. Its fields describe the data shape of other documents in that collection.
 
@@ -79,7 +79,7 @@ The following field names are not rendered as form inputs and are managed automa
 
 ---
 
-## Using the `<Collection>` Component
+#### Using the `<Collection>` Component
 
 The simplest way to use the CRUD system is via the `<Collection>` component, which orchestrates all four CRUD modes automatically.
 
@@ -104,7 +104,7 @@ import { Collection } from '@/NX/NXAdmin';
 
 ---
 
-## CRUD Mode Flow
+#### CRUD Mode Flow
 
 ```
                     ┌─────────────┐
@@ -147,7 +147,7 @@ dispatch(setCRUD('products', 'selected', null));
 
 ---
 
-## `initCollection` — Data Fetching
+#### `initCollection` — Data Fetching
 
 `initCollection` initialises the Redux state for a collection and fetches documents.
 
@@ -187,7 +187,7 @@ The search filter runs client-side on the following fields (normalised, diacriti
 
 ---
 
-## Standalone CRUD Components
+#### Standalone CRUD Components
 
 You can use the four CRUD components directly without `<Collection>` if you need custom layout.
 
@@ -214,7 +214,7 @@ Confirmation dialog. On confirm, calls `collectionDelete`.
 
 ---
 
-## Building a Custom Collection Page
+#### Building a Custom Collection Page
 
 ```tsx
 'use client';

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/hooks.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/hooks.md
@@ -16,7 +16,7 @@ All hooks are exported from `app/NX/NXAdmin/index.tsx`. They are client-side onl
 
 ---
 
-## `useNXAdmin()`
+#### `useNXAdmin()`
 
 Returns the entire `nxAdmin` Redux slice.
 
@@ -44,7 +44,7 @@ function MyComponent() {
 
 ---
 
-## `useCRUD()`
+#### `useCRUD()`
 
 Returns the `nxAdmin.crud` slice — the state map for all initialised collections.
 
@@ -82,7 +82,7 @@ function MyComponent() {
 
 ---
 
-## `useCollection(collection)`
+#### `useCollection(collection)`
 
 Convenience hook that returns the CRUD state for a single named collection.
 
@@ -105,7 +105,7 @@ function ProductList() {
 
 ---
 
-## `useActive()`
+#### `useActive()`
 
 Returns the current active route key (`nxAdmin.active`).
 
@@ -124,7 +124,7 @@ function NavItem({ collection }) {
 
 ---
 
-## `useNotifications()`
+#### `useNotifications()`
 
 Registers a foreground FCM message listener. Should be called once, at the shell level (it is called automatically inside `<MiniDrawer>`).
 
@@ -151,7 +151,7 @@ function CustomShell() {
 
 ---
 
-## `useHeader()`
+#### `useHeader()`
 
 Returns the current page header state (`nxAdmin.header`).
 
@@ -170,7 +170,7 @@ function MyHeader() {
 
 ---
 
-## Setting the Header
+#### Setting the Header
 
 Any page component can update the top-bar header by dispatching `setNXAdmin`:
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/hooks.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/hooks.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin/hooks
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Hooks</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin, hooks

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/index.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Nx Admin</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/index.md
@@ -24,7 +24,7 @@ Dashboard is a full back-office administration panel that plugs into any NX° ho
 
 ---
 
-## Documentation Index
+#### Documentation Index
 
 | Document | Description |
 |---|---|
@@ -38,7 +38,7 @@ Dashboard is a full back-office administration panel that plugs into any NX° ho
 
 ---
 
-## Quick Start
+#### Quick Start
 
 ### 1. Mount the cartridge
 
@@ -77,7 +77,7 @@ Copy `public/firebase-messaging-sw.js` to the root of your `public/` folder. Thi
 
 ---
 
-## How It Works
+#### How It Works
 
 ```
 <NXAdmin config={…}>
@@ -123,7 +123,7 @@ The active route is derived from the URL pathname. `MiniDrawer` syncs the URL wi
 
 ---
 
-## Redux State Shape
+#### Redux State Shape
 
 Dashboard stores all its state under `state.redux.nxAdmin`:
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/notifications.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/notifications.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin/notifications
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Notifications</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin, notifications

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/notifications.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/notifications.md
@@ -16,7 +16,7 @@ Dashboard integrates Firebase Cloud Messaging (FCM) to deliver push notification
 
 ---
 
-## Architecture
+#### Architecture
 
 ```
 Server                    Client (tab open)          Background SW
@@ -38,7 +38,7 @@ Server                    Client (tab open)          Background SW
 
 ---
 
-## Setup
+#### Setup
 
 ### 1. Environment variables
 
@@ -67,7 +67,7 @@ Place `notification.mp3` at `public/nxadmin/mp3/notification.mp3`. This file is 
 
 ---
 
-## Permission & Token Flow
+#### Permission & Token Flow
 
 The `requestNotifications` action handles the full permission → token → persist flow:
 
@@ -104,7 +104,7 @@ state.redux.nxAdmin.notifications = {
 
 ---
 
-## Foreground Messages (`useNotifications`)
+#### Foreground Messages (`useNotifications`)
 
 The `useNotifications` hook registers an `onMessage` listener for when the app tab is focused. It is called automatically by `<MiniDrawer>`.
 
@@ -128,7 +128,7 @@ function CustomShell() {
 
 ---
 
-## The Notification Bell (`<NotificationBell>`)
+#### The Notification Bell (`<NotificationBell>`)
 
 The `<NotificationBell>` component in the top app bar shows the unread notification count and allows users to request permission or clear the badge.
 
@@ -146,7 +146,7 @@ import { NotificationBell } from '@/NX/NXAdmin';
 
 ---
 
-## Sending Notifications from the Server
+#### Sending Notifications from the Server
 
 Use the `/api/notify` route to send notifications to one or more users.
 
@@ -168,7 +168,7 @@ The route uses `firebase-admin` and `sendEachForMulticast` to fan the message ou
 
 ---
 
-## Background Notifications
+#### Background Notifications
 
 Background notifications are handled by `public/firebase-messaging-sw.js`. When a push arrives while the tab is not focused:
 
@@ -180,7 +180,7 @@ Background notifications are handled by `public/firebase-messaging-sw.js`. When 
 
 ---
 
-## Testing Push Notifications
+#### Testing Push Notifications
 
 1. Open the browser console after signing in — the FCM token is logged as `"Your FCM Token: …"`.
 2. Copy the token.

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/pwa.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/pwa.md
@@ -16,13 +16,13 @@ Dashboard includes built-in Progressive Web App (PWA) install prompt management.
 
 ---
 
-## Overview
+#### Overview
 
 The PWA system is driven by two actions (`pwaAlert`, `triggerPwaInstall`) and the `<PWAAlert>` component. State is stored under `state.redux.nxAdmin.pwa`.
 
 ---
 
-## Redux State Shape
+#### Redux State Shape
 
 ```ts
 state.redux.nxAdmin.pwa = {
@@ -36,7 +36,7 @@ state.redux.nxAdmin.pwa = {
 
 ---
 
-## `pwaAlert()` Action
+#### `pwaAlert()` Action
 
 Initialises PWA state and registers `beforeinstallprompt` and `appinstalled` event listeners. Called automatically by `<MiniDrawer>` on mount — you do not need to call it manually in standard setups.
 
@@ -59,7 +59,7 @@ dispatch(pwaAlert());
 
 ---
 
-## `triggerPwaInstall()` Action
+#### `triggerPwaInstall()` Action
 
 Triggers the browser's native install dialog using the previously deferred `BeforeInstallPromptEvent`.
 
@@ -83,7 +83,7 @@ const accepted: boolean = await dispatch(triggerPwaInstall());
 
 ---
 
-## `<PWAAlert>` Component
+#### `<PWAAlert>` Component
 
 Renders the install prompt UI when the app is installable. Mount it anywhere inside the admin shell.
 
@@ -103,7 +103,7 @@ import { PWAAlert } from '@/NX/NXAdmin';
 
 ---
 
-## Checking PWA State in Components
+#### Checking PWA State in Components
 
 ```tsx
 import { useNXAdmin } from '@/NX/NXAdmin';
@@ -124,7 +124,7 @@ function InstallBanner() {
 
 ---
 
-## Requirements
+#### Requirements
 
 - The app must be served over **HTTPS** (or `localhost`) — `isSecureContext` must be `true`.
 - A **service worker** must be registered. The `firebase-messaging-sw.js` file in `public/` satisfies this requirement.
@@ -132,7 +132,7 @@ function InstallBanner() {
 
 ---
 
-## Detecting Standalone Mode
+#### Detecting Standalone Mode
 
 The `installed` flag is set to `true` when the app is already running as a PWA:
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/pwa.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/cartridges/nx-admin/pwa.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/cartridges/nx-admin/pwa
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° PWA</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, cartridges, nx-admin, pwa

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/config.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/config.md
@@ -16,7 +16,7 @@ Every NX° application is driven by a single configuration object that is passed
 
 ---
 
-## Schema
+#### Schema
 
 ```ts
 type T_Config = {
@@ -51,7 +51,7 @@ type T_Config = {
 
 ---
 
-## `cartridges.designSystem`
+#### `cartridges.designSystem`
 
 Controls theming across the entire application.
 
@@ -116,7 +116,7 @@ type T_DesignSystemCartridge = {
 
 ---
 
-## How Config Flows Through the App
+#### How Config Flows Through the App
 
 1. `config.json` is imported at the page / layout level.
 2. It is passed as the `config` prop to `<NX>` and `<NXAdmin>`.
@@ -126,7 +126,7 @@ type T_DesignSystemCartridge = {
 
 ---
 
-## TypeScript tip
+#### TypeScript tip
 
 Import `T_Config` from the framework types file to get full type-safety:
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/config.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/config.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/framework/config
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Config</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, framework, config

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/design-system.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/design-system.md
@@ -16,7 +16,7 @@ The `DesignSystem` cartridge provides MUI (Material UI v6) theming, global feedb
 
 ---
 
-## Mounting
+#### Mounting
 
 `<DesignSystem>` is mounted automatically by `<NX>` and `<NXAdmin>` — you do not need to render it manually unless you are building a standalone cartridge.
 
@@ -30,7 +30,7 @@ import { DesignSystem } from '@/NX/DesignSystem';
 
 ---
 
-## Public API (`app/NX/DesignSystem/index.tsx`)
+#### Public API (`app/NX/DesignSystem/index.tsx`)
 
 ### Actions
 
@@ -70,7 +70,7 @@ import { DesignSystem } from '@/NX/DesignSystem';
 
 ---
 
-## Theming
+#### Theming
 
 Themes are defined in `config.json` under `cartridges.designSystem.themes`. The active theme key is stored in `state.redux.designSystem.themeMode`.
 
@@ -89,7 +89,7 @@ function ThemeToggle() {
 
 ---
 
-## Footer Layout
+#### Footer Layout
 
 The shared `Footer` is rendered as a fixed bottom `AppBar`.
 
@@ -107,7 +107,7 @@ Primary implementation styles live in `packages/design-system/src/styles/site-la
 
 ---
 
-## Feedback Toasts
+#### Feedback Toasts
 
 Any cartridge can dispatch a toast by calling `setFeedback`:
 
@@ -128,7 +128,7 @@ The `<Feedback />` component must be mounted somewhere in the tree (it is includ
 
 ---
 
-## Icon Component
+#### Icon Component
 
 `<Icon>` renders one of the 200+ named icons in the NX° icon library.
 

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/design-system.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/design-system.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/framework/design-system
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Design System</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, framework, design-system

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/index.md
@@ -7,7 +7,7 @@ icon: docs
 tags: docs
 ---
 
-## Admin Framework
+#### Admin Framework
 
 - [Overview](/docs/apps/admin/framework/overview)
 - [Config](/docs/apps/admin/framework/config)

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/overview.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/overview.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/framework/overview
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Overview</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, framework, overview

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/overview.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/overview.md
@@ -12,7 +12,7 @@ NX repository documentation
 
 # NX° Framework — Architecture Overview
 
-## The Cartridge Model
+#### The Cartridge Model
 
 NX° is built around the concept of **cartridges** — discrete, self-contained feature modules that plug into a shared host shell. Each cartridge:
 
@@ -26,7 +26,7 @@ This design makes it possible to add, remove, or swap an entire feature (e.g. Ad
 
 ---
 
-## Directory Structure
+#### Directory Structure
 
 ```
 app/
@@ -46,7 +46,7 @@ app/
 
 ---
 
-## Core Components
+#### Core Components
 
 ### `<NX>` — Root wrapper
 
@@ -69,7 +69,7 @@ import { NX } from '@/NX';
 
 ---
 
-## Lifecycle of a Request
+#### Lifecycle of a Request
 
 ```
 Browser Request
@@ -82,7 +82,7 @@ Browser Request
 
 ---
 
-## Shared Types (`types.d.ts`)
+#### Shared Types (`types.d.ts`)
 
 Key types shared across all cartridges:
 
@@ -98,7 +98,7 @@ Key types shared across all cartridges:
 
 ---
 
-## Available Cartridges
+#### Available Cartridges
 
 | Cartridge | Directory | Purpose |
 |---|---|---|

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/uberedux.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/uberedux.md
@@ -16,7 +16,7 @@ Uberedux is NX°'s shared Redux layer. It wraps Redux Toolkit's `configureStore`
 
 ---
 
-## Philosophy
+#### Philosophy
 
 Instead of separate reducers for every cartridge, Uberedux uses a **single flat slice** (`redux`) with a generic `setUbereduxKey` action that accepts a dot-separated key path and a value. This means:
 
@@ -26,7 +26,7 @@ Instead of separate reducers for every cartridge, Uberedux uses a **single flat 
 
 ---
 
-## Store Structure
+#### Store Structure
 
 ```
 store.getState()
@@ -41,7 +41,7 @@ store.getState()
 
 ---
 
-## API
+#### API
 
 ### `UbereduxProvider`
 
@@ -120,7 +120,7 @@ function MyComponent() {
 
 ---
 
-## Writing a Cartridge Action
+#### Writing a Cartridge Action
 
 All cartridge actions follow the same thunk pattern:
 
@@ -143,7 +143,7 @@ export const myAction = (payload: string): any =>
 
 ---
 
-## TypeScript Types
+#### TypeScript Types
 
 | Type | Description |
 |---|---|

--- a/apps/www/public/nx/markdown/docs/apps/admin/framework/uberedux.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/framework/uberedux.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin/framework/uberedux
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Uberedux</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, framework, uberedux

--- a/apps/www/public/nx/markdown/docs/apps/admin/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/index.md
@@ -6,19 +6,6 @@ slug: /docs/apps/admin
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Admin</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, admin, admin

--- a/apps/www/public/nx/markdown/docs/apps/admin/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/admin/index.md
@@ -16,13 +16,13 @@ Welcome to the official documentation for the **NX° Framework** — a modular, 
 
 ---
 
-## What is NX°?
+#### What is NX°?
 
 NX° is a composable application framework. Rather than a monolithic codebase, NX° apps are assembled from self-contained **cartridges** — pluggable modules that can be switched on or off per project. Each cartridge owns its own components, actions, hooks, and Redux state slice, making it trivially portable between NX° host applications.
 
 ---
 
-## Documentation Index
+#### Documentation Index
 
 ### Framework Core
 
@@ -41,7 +41,7 @@ NX° is a composable application framework. Rather than a monolithic codebase, N
 
 ---
 
-## Quick-start
+#### Quick-start
 
 ```tsx
 // app/layout.tsx (or your root page)
@@ -74,7 +74,7 @@ export default function AdminPage() {
 
 ---
 
-## Conventions
+#### Conventions
 
 - Every cartridge is located under `app/NX/<CartridgeName>/`.
 - Each cartridge exposes its public API through a barrel `index.tsx`.

--- a/apps/www/public/nx/markdown/docs/apps/flash/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/flash/index.md
@@ -7,6 +7,6 @@ icon: docs
 tags: docs
 ---
 
-## Flash
+#### Flash
 
 - [Sprite](/docs/apps/flash/sprite)

--- a/apps/www/public/nx/markdown/docs/apps/flash/sprite.md
+++ b/apps/www/public/nx/markdown/docs/apps/flash/sprite.md
@@ -6,19 +6,6 @@ slug: /docs/apps/flash/sprite
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Sprite</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps, flash, sprite

--- a/apps/www/public/nx/markdown/docs/apps/flash/sprite.md
+++ b/apps/www/public/nx/markdown/docs/apps/flash/sprite.md
@@ -14,7 +14,7 @@ NX repository documentation
 
 This folder contains a reusable SVG character sprite with 8-direction facing and a 4-frame walk cycle.
 
-## What this is
+#### What this is
 
 The sprite is designed to look blocky (Minecraft-like) while still being scalable SVG, not pixel/raster art.
 
@@ -26,7 +26,7 @@ It currently supports:
 - internal timer-based animation by default
 - optional parent-controlled frame via `frame` prop
 
-## File structure
+#### File structure
 
 - `Sprite.tsx`: React-facing component API + animation timing/frame selection
 - `SpriteArtwork.tsx`: SVG geometry and pose logic
@@ -37,7 +37,7 @@ Public types are centralized in the package root declarations file:
 
 - `../../../types` (actual file: `types.d.ts` at package root)
 
-## How rendering works
+#### How rendering works
 
 `Sprite` computes the active state and active frame, then renders `SpriteArtwork`.
 
@@ -54,7 +54,7 @@ Public types are centralized in the package root declarations file:
 - `idleFps` for idle (default `2`)
 - `animateIdle` controls whether idle ticks or remains static
 
-## How artwork works
+#### How artwork works
 
 `SpriteArtwork` uses reusable SVG primitives (rectangles/ellipse) for:
 
@@ -79,7 +79,7 @@ The walking cycle is driven by small numeric patterns:
 
 This creates motion that reads as walking rather than sliding.
 
-## Direction utility
+#### Direction utility
 
 `getDirection(dx, dy, fallback)` in `direction.ts` maps a movement vector to the nearest of 8 octants.
 
@@ -90,7 +90,7 @@ Convention used here:
 
 If `dx=0` and `dy=0`, it returns `fallback` (default `"S"`).
 
-## Usage
+#### Usage
 
 From package exports:
 
@@ -132,7 +132,7 @@ Palette override:
 />
 ```
 
-## Extension notes
+#### Extension notes
 
 Good next steps if you want more features without rewriting the core:
 

--- a/apps/www/public/nx/markdown/docs/apps/index.md
+++ b/apps/www/public/nx/markdown/docs/apps/index.md
@@ -1,24 +1,10 @@
 ---
 order: 9013
 title: App Docs
-description: <div>
 slug: /docs/apps
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Apps</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, apps

--- a/apps/www/public/nx/markdown/docs/business/about.md
+++ b/apps/www/public/nx/markdown/docs/business/about.md
@@ -6,19 +6,6 @@ slug: /docs/business/about
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° About</span>
-    </h1>
-</div>
-
 Goldlabel Apps Ltd
 
 > Tags: docs, business, about

--- a/apps/www/public/nx/markdown/docs/business/executive-overview.md
+++ b/apps/www/public/nx/markdown/docs/business/executive-overview.md
@@ -23,13 +23,13 @@ NX repository documentation
 	</h1>
 </div>
 
-## Executive Summary
+#### Executive Summary
 
 NX° is a product platform for building and operating multiple digital experiences from one shared codebase. The repository already demonstrates a strong foundation for shipping a polished product with clear architecture, reusable UI, and a scalable operating model.
 
 The central message is simple: NX° is not just a collection of apps. It is a platform for composing products, workflows, and shared capabilities efficiently.
 
-## The 5 Ws
+#### The 5 Ws
 
 ### What is NX°?
 
@@ -65,7 +65,7 @@ The value is concentrated in the shared platform layer and the product surfaces 
 
 It matters now because NX° is at the point where product clarity, platform maturity, and shipping discipline become visible. This is where strong foundations become obvious to new contributors and stakeholders alike.
 
-## Platform Positioning
+#### Platform Positioning
 
 NX° is designed as a flexible foundation for building ambitious digital products without fragmenting the codebase. It gives teams a way to:
 
@@ -74,7 +74,7 @@ NX° is designed as a flexible foundation for building ambitious digital product
 - keep internal tools and customer-facing apps aligned
 - scale without rebuilding the same infrastructure repeatedly
 
-## What the Repository Already Shows
+#### What the Repository Already Shows
 
 The current repository demonstrates a credible product platform foundation:
 
@@ -86,7 +86,7 @@ The current repository demonstrates a credible product platform foundation:
 
 This is the difference between a one-off prototype and a platform that can evolve.
 
-## Why This Is Compelling
+#### Why This Is Compelling
 
 NX° is attractive because it combines product ambition with implementation discipline. The codebase is not just organized — it is designed for reuse, coordination, and continued development.
 
@@ -96,7 +96,7 @@ That makes it especially strong for teams that need to:
 - maintain product quality across multiple surfaces
 - onboard contributors into a coherent system
 
-## Current Product Momentum
+#### Current Product Momentum
 
 Recent work continues to reinforce the platform story:
 
@@ -105,14 +105,14 @@ Recent work continues to reinforce the platform story:
 - shared UI and design-system maturity
 - documentation and delivery guardrails improving alongside product work
 
-## What a New Reader Should Take Away
+#### What a New Reader Should Take Away
 
 1. NX° is a real product platform, not just a demo repository.
 2. It has clear product surfaces and a reusable shared foundation.
 3. It is structured for iteration, growth, and team collaboration.
 4. It presents a credible path from MVP toward a broader product ecosystem.
 
-## Read Next
+#### Read Next
 
 - [Owner Guide](./owner-guide.md)
 - [Developer Guide](../engineering/developer-guide.md)

--- a/apps/www/public/nx/markdown/docs/business/executive-overview.md
+++ b/apps/www/public/nx/markdown/docs/business/executive-overview.md
@@ -6,19 +6,6 @@ slug: /docs/business/executive-overview
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Executive Overview</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, business, executive-overview

--- a/apps/www/public/nx/markdown/docs/business/index.md
+++ b/apps/www/public/nx/markdown/docs/business/index.md
@@ -6,19 +6,6 @@ slug: /docs/business
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Business</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, business

--- a/apps/www/public/nx/markdown/docs/business/investor-overview.md
+++ b/apps/www/public/nx/markdown/docs/business/investor-overview.md
@@ -23,11 +23,11 @@ NX repository documentation
 	</h1>
 </div>
 
-## Why This Document Exists
+#### Why This Document Exists
 
 This overview explains why the Leida repository represents more than a concept. It shows the breadth of execution already completed and why the current MVP phase is building on a credible software foundation.
 
-## Investment-Level Summary
+#### Investment-Level Summary
 
 Leida is already supported by:
 
@@ -39,7 +39,7 @@ Leida is already supported by:
 
 In plain terms, the team has already done a meaningful amount of the hidden work that turns an idea into a viable product platform.
 
-## The 5 Ws for an Investor
+#### The 5 Ws for an Investor
 
 ### What has been built?
 
@@ -85,7 +85,7 @@ At MVP stage. This is when a project needs to prove it can:
 - evolve
 - support investment into refinement and growth rather than reinvention
 
-## Why the Current State Is Valuable
+#### Why the Current State Is Valuable
 
 The strongest investor signal in this repository is not any one feature. It is the combination of:
 
@@ -97,7 +97,7 @@ The strongest investor signal in this repository is not any one feature. It is t
 
 That combination suggests the team is building a platform, not just a demo.
 
-## Scope Already Covered
+#### Scope Already Covered
 
 The repository spans several layers of product value.
 
@@ -122,7 +122,7 @@ The shared framework and design-system work provide long-term leverage:
 - shared theme and component assets
 - centralized documentation
 
-## Why This Lowers Execution Risk
+#### Why This Lowers Execution Risk
 
 A well-structured repository lowers several common startup risks:
 
@@ -134,7 +134,7 @@ A well-structured repository lowers several common startup risks:
 
 Leida has not eliminated all risk, but it has clearly reduced these specific categories.
 
-## Evidence From Project Evolution
+#### Evidence From Project Evolution
 
 Recent commit history shows several healthy patterns:
 
@@ -147,7 +147,7 @@ Recent commit history shows several healthy patterns:
 
 This is the kind of history you expect in a team moving from concept toward operational MVP.
 
-## What “Solid Foundation” Means Here
+#### What “Solid Foundation” Means Here
 
 In this repository, a solid foundation means:
 
@@ -159,13 +159,13 @@ In this repository, a solid foundation means:
 
 That is exactly the kind of work investors often need to know has already been done.
 
-## Honest Current-State Framing
+#### Honest Current-State Framing
 
 This is still an active MVP phase, not a finished end-state platform. Some flows are being refined, and parts of the product are still in motion. But the important point is that those refinements are happening on top of structure, documentation, and reusable assets.
 
 The project is not trying to discover its shape anymore. It is sharpening it.
 
-## Last-Week Momentum (2026-07-27 to 2026-08-03)
+#### Last-Week Momentum (2026-07-27 to 2026-08-03)
 
 Recent commits reinforce execution momentum:
 
@@ -175,11 +175,11 @@ Recent commits reinforce execution momentum:
 - design-system and Storybook maintenance continued alongside product work
 - docs/media cleanup and asset pruning improved operational discipline
 
-## Best Investor-Level Takeaway
+#### Best Investor-Level Takeaway
 
 > Leida has already completed a substantial layer of platform-building work across product experience, internal operations, architecture, and documentation, which puts the project in a stronger position to convert effort and funding into product refinement and growth rather than foundational rebuilds.
 
-## Read Next
+#### Read Next
 
 - [Executive Overview](./executive-overview.md)
 - [Owner Guide](./owner-guide.md)

--- a/apps/www/public/nx/markdown/docs/business/investor-overview.md
+++ b/apps/www/public/nx/markdown/docs/business/investor-overview.md
@@ -6,19 +6,6 @@ slug: /docs/business/investor-overview
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Investor Overview</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, business, investor-overview

--- a/apps/www/public/nx/markdown/docs/business/operations-and-delivery.md
+++ b/apps/www/public/nx/markdown/docs/business/operations-and-delivery.md
@@ -23,11 +23,11 @@ NX repository documentation
 	</h1>
 </div>
 
-## Purpose
+#### Purpose
 
 This guide covers the operating model, validation steps, and delivery practices that keep NX° reliable as it grows.
 
-## The 5 Ws of Operations
+#### The 5 Ws of Operations
 
 ### What is being operated?
 
@@ -61,7 +61,7 @@ Because modern product delivery depends on more than a polished frontend. It als
 - when changing shared packages or runtime layers
 - when deploying to Vercel or validating production readiness
 
-## Delivery Workflow
+#### Delivery Workflow
 
 A dependable delivery flow for NX° typically looks like this:
 
@@ -71,7 +71,7 @@ A dependable delivery flow for NX° typically looks like this:
 4. review shared package and runtime impact
 5. ship with clear release awareness
 
-## Core Operational Domains
+#### Core Operational Domains
 
 ### Product Experience
 
@@ -85,7 +85,7 @@ The admin experience sits in `apps/admin` and supports the internal tool layer t
 
 The shared packages and runtime layers are where much of the platform’s leverage lives. Changes here should be reviewed carefully because they can affect multiple apps.
 
-## Environment Requirements
+#### Environment Requirements
 
 ### Runtime and Tooling
 
@@ -103,7 +103,7 @@ The shared packages and runtime layers are where much of the platform’s levera
 
 Tenant configuration should be present for the active deployment target in the relevant app public directory.
 
-## Validation Commands
+#### Validation Commands
 
 Workspace-level:
 
@@ -116,18 +116,18 @@ App-level:
 - `pnpm --filter www test`
 - `pnpm --filter admin typecheck`
 
-## Deployment Posture
+#### Deployment Posture
 
 NX° is designed to support app-specific deployment rather than a single monorepo-root deployment. Deployment should be treated as an app-level concern with clear validation and environment checks.
 
-## Common Failure Modes
+#### Common Failure Modes
 
 - missing or incomplete env configuration
 - misconfigured tenant settings
 - deployment root mismatches
 - shared package changes that affect multiple apps unexpectedly
 
-## Recommended Release Checklist
+#### Recommended Release Checklist
 
 1. Confirm the app root and deployment target.
 2. Confirm required environment variables for the selected app.
@@ -136,7 +136,7 @@ NX° is designed to support app-specific deployment rather than a single monorep
 5. Run relevant app tests.
 6. Review shared package and runtime impact before shipping.
 
-## Read Next
+#### Read Next
 
 - [Developer Guide](../engineering/developer-guide.md)
 - [Project Evolution](../concepts/project-evolution.md)

--- a/apps/www/public/nx/markdown/docs/business/operations-and-delivery.md
+++ b/apps/www/public/nx/markdown/docs/business/operations-and-delivery.md
@@ -6,19 +6,6 @@ slug: /docs/business/operations-and-delivery
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Operations And Delivery</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, business, operations-and-delivery

--- a/apps/www/public/nx/markdown/docs/business/owner-guide.md
+++ b/apps/www/public/nx/markdown/docs/business/owner-guide.md
@@ -6,19 +6,6 @@ slug: /docs/business/owner-guide
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Owner Guide</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, business, owner-guide

--- a/apps/www/public/nx/markdown/docs/business/owner-guide.md
+++ b/apps/www/public/nx/markdown/docs/business/owner-guide.md
@@ -23,11 +23,11 @@ NX repository documentation
 	</h1>
 </div>
 
-## Purpose of This Guide
+#### Purpose of This Guide
 
 This guide explains NX° from an owner’s point of view: what has been built, why it matters, what the platform can already do, and what the current repository says about delivery readiness.
 
-## The 5 Ws for the Owner
+#### The 5 Ws for the Owner
 
 ### What has been built?
 
@@ -70,7 +70,7 @@ The value is distributed across:
 
 Now, during product delivery, because this is the moment where ambiguity creates risk. NX° reduces that risk by making the system inspectable, documented, and extendable.
 
-## What the Owner Should Understand About Scope
+#### What the Owner Should Understand About Scope
 
 NX° spans more than one product layer.
 
@@ -88,7 +88,7 @@ This includes the shared runtime, design system, state patterns, and product doc
 
 This third layer is the difference between “a working app” and “a platform that can keep evolving.”
 
-## Why the Monorepo Matters Strategically
+#### Why the Monorepo Matters Strategically
 
 The monorepo is not just a developer preference. It creates business value:
 
@@ -98,7 +98,7 @@ The monorepo is not just a developer preference. It creates business value:
 - future features can reuse the same foundation
 - documentation can be centralized and kept in step with the code
 
-## Evidence of a Professional Foundation
+#### Evidence of a Professional Foundation
 
 The repository already shows several signs of maturity:
 
@@ -109,7 +109,7 @@ The repository already shows several signs of maturity:
 - UI concerns are being extracted into reusable packages
 - the codebase shows steady refinement rather than ad-hoc experimentation
 
-## Operational Capability Already Present
+#### Operational Capability Already Present
 
 The admin experience is not a placeholder. It captures real operational concerns and supports a more complete product story:
 
@@ -117,7 +117,7 @@ The admin experience is not a placeholder. It captures real operational concerns
 - shared product infrastructure is treated as a first-class asset
 - delivery and maintenance concerns are visible rather than hidden
 
-## Commercial Meaning of the Current State
+#### Commercial Meaning of the Current State
 
 From an ownership perspective, the most important message is:
 
@@ -132,7 +132,7 @@ That includes:
 
 These are the kinds of investments that make a platform easier to grow and harder to abandon.
 
-## Current Risks the Owner Should Be Aware Of
+#### Current Risks the Owner Should Be Aware Of
 
 The repository is strong, but it is still in refinement mode.
 
@@ -142,20 +142,20 @@ The repository is strong, but it is still in refinement mode.
 - parts of the product and docs are evolving as the platform matures
 - final polish is still part of the active roadmap
 
-## What the Owner Can Confidently Say
+#### What the Owner Can Confidently Say
 
 An accurate owner-level statement would be:
 
 > NX° has moved from proof of concept into a structured product platform with public and operational applications, shared infrastructure, reusable UI assets, documentation, and clear room for iterative refinement rather than replatforming.
 
-## Suggested Owner-Level Next Steps
+#### Suggested Owner-Level Next Steps
 
 1. Keep this handover pack updated at key milestones.
 2. Use the operations and admin docs to define short-term launch readiness criteria.
 3. Treat the developer guide as the onboarding base for any new technical contributor.
 4. Use the executive and investor overview as the business-facing explanation of why the platform is more substantial than an early prototype.
 
-## Read Next
+#### Read Next
 
 - [Executive Overview](./executive-overview.md)
 - [Investor Overview](./investor-overview.md)

--- a/apps/www/public/nx/markdown/docs/concepts/experience/ai/index.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/ai/index.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/ai
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° AI</span>
-    </h1>
-</div>
-
 What would a Software Developer know about AI?
 
 > Tags: docs, concepts, experience, ai

--- a/apps/www/public/nx/markdown/docs/concepts/experience/ai/ollama.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/ai/ollama.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/ai/ollama
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Ollama</span>
-    </h1>
-</div>
-
 Run LLMs on your own device
 
 > Tags: docs, concepts, experience, ai, ollama

--- a/apps/www/public/nx/markdown/docs/concepts/experience/ai/open-claw.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/ai/open-claw.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/ai/open-claw
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Open Claw</span>
-    </h1>
-</div>
-
 Claw Ensemble Learning is a meta-learning framework
 
 > Tags: docs, concepts, experience, ai, open-claw

--- a/apps/www/public/nx/markdown/docs/concepts/experience/ai/phi-3.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/ai/phi-3.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/ai/phi-3
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Phi-3</span>
-    </h1>
-</div>
-
 High performance Microsoft models
 
 > Tags: docs, concepts, experience, ai, phi-3

--- a/apps/www/public/nx/markdown/docs/concepts/experience/ai/prompts.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/ai/prompts.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/ai/prompts
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Prompts</span>
-    </h1>
-</div>
-
 Proper Prompt Engineering
 
 > Tags: docs, concepts, experience, ai, prompts

--- a/apps/www/public/nx/markdown/docs/concepts/experience/despecialisation.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/despecialisation.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/despecialisation
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Despecialisation</span>
-    </h1>
-</div>
-
 How quickly can you despecialise?
 
 > Tags: docs, concepts, experience, despecialise

--- a/apps/www/public/nx/markdown/docs/concepts/experience/high-trust.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/high-trust.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/high-trust
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° High Trust</span>
-    </h1>
-</div>
-
 Solo Technical Operator
 
 > Tags: docs, concepts, experience, solo

--- a/apps/www/public/nx/markdown/docs/concepts/experience/index.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/index.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Experience</span>
-    </h1>
-</div>
-
 2 decades of experience
 
 > Tags: docs, concepts, experience

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/git.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/git.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/git
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Git</span>
-    </h1>
-</div>
-
 Proud to share code
 
 > Tags: docs, concepts, experience, techstack, git

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/index.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/index.md
@@ -7,7 +7,7 @@ icon: docs
 tags: docs
 ---
 
-## Experience Techstack
+#### Experience Techstack
 
 - [Git](/docs/concepts/experience/techstack/git)
 - [Next.js](/docs/concepts/experience/techstack/next-js)

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/next-js.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/next-js.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/next-js
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Next.js</span>
-    </h1>
-</div>
-
 Fullstack Node and React
 
 > Tags: docs, concepts, experience, techstack, nextjs

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/python/fastapi.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/python/fastapi.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/python/fastapi
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° FastAPI</span>
-    </h1>
-</div>
-
 High performance and easy-to-use APIs
 
 > Tags: docs, concepts, experience, techstack, python, fastapi

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/python/index.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/python/index.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/python
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Python</span>
-    </h1>
-</div>
-
 Central to AI and automation
 
 > Tags: docs, concepts, experience, techstack, python

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/python/tsvector.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/python/tsvector.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/python/tsvector
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° tsvector</span>
-    </h1>
-</div>
-
 Superfast full text search
 
 > Tags: docs, concepts, experience, techstack, python, tsvector

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/react.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/react.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/react
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° React</span>
-    </h1>
-</div>
-
 by facebook
 
 > Tags: docs, concepts, experience, techstack, react

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/specialisation.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/specialisation.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/specialisation
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Specialisation</span>
-    </h1>
-</div>
-
 The techstack we work with
 
 > Tags: docs, concepts, experience, techstack

--- a/apps/www/public/nx/markdown/docs/concepts/experience/techstack/typescript.md
+++ b/apps/www/public/nx/markdown/docs/concepts/experience/techstack/typescript.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/experience/techstack/typescript
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° TypeScript</span>
-    </h1>
-</div>
-
 Statically typed superset of JavaScript
 
 > Tags: docs, concepts, experience, techstack, typescript

--- a/apps/www/public/nx/markdown/docs/concepts/index.md
+++ b/apps/www/public/nx/markdown/docs/concepts/index.md
@@ -6,19 +6,6 @@ slug: /docs/concepts
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Concepts</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, concepts

--- a/apps/www/public/nx/markdown/docs/concepts/nx.md
+++ b/apps/www/public/nx/markdown/docs/concepts/nx.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/nx
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° NX°</span>
-    </h1>
-</div>
-
 Imported from www markdown content
 
 > Tags: docs, concepts, nx-overview

--- a/apps/www/public/nx/markdown/docs/concepts/project-evolution.md
+++ b/apps/www/public/nx/markdown/docs/concepts/project-evolution.md
@@ -23,13 +23,13 @@ NX repository documentation
 	</h1>
 </div>
 
-## Purpose
+#### Purpose
 
 This document summarizes how Leida has evolved and what changed most recently.
 
 It is a narrative summary, not a full changelog.
 
-## Big-Picture Arc
+#### Big-Picture Arc
 
 The repository progression is:
 
@@ -40,7 +40,7 @@ The repository progression is:
 5. AWIN and product-flow refinement
 6. route and UX cleanup across public/founder surfaces
 
-## Phase 1: Foundation and Shared UI Direction
+#### Phase 1: Foundation and Shared UI Direction
 
 Early work established a reusable design-system base, tokenization, and package-level component exports.
 
@@ -50,7 +50,7 @@ Why it mattered:
 - introduced reusable visual primitives
 - established a package-first UI direction
 
-## Phase 2: Documentation as an Asset
+#### Phase 2: Documentation as an Asset
 
 Docs were consolidated into a centralized handover set.
 
@@ -60,7 +60,7 @@ Why it mattered:
 - made architecture and operations legible
 - reduced dependency on tribal knowledge
 
-## Phase 3: Founder Operational Surface
+#### Phase 3: Founder Operational Surface
 
 Founder app capabilities became a dedicated operational control plane.
 
@@ -71,7 +71,7 @@ Core capabilities:
 - queue decisioning and processing
 - product list and curation flows
 
-## Phase 4: Technical Hardening
+#### Phase 4: Technical Hardening
 
 Repository history shows repeated hardening work around typing, script discipline, and build safety.
 
@@ -81,7 +81,7 @@ Signals include:
 - improved runtime/config consistency
 - build and deployment guardrail scripting
 
-## Phase 5: AWIN Workflow Refinement
+#### Phase 5: AWIN Workflow Refinement
 
 AWIN moved from basic integration to operator-focused flow improvements.
 
@@ -91,7 +91,7 @@ Focus areas:
 - ingest and feed sync control
 - queue and bulk action handling
 
-## Phase 6: Product Shelf and Routine Flow Evolution
+#### Phase 6: Product Shelf and Routine Flow Evolution
 
 Public product/routine flows were reshaped around clearer domain semantics and better practitioner workflows.
 
@@ -101,7 +101,7 @@ Observed trajectory:
 - route split between preview/edit contexts
 - richer routine authoring and viewing capabilities
 
-## Phase 7: Shared Component Maturity
+#### Phase 7: Shared Component Maturity
 
 Design-system assets continued to absorb reusable component work.
 
@@ -111,7 +111,7 @@ Examples:
 - image stack additions (`Image`, `Thumbnail`, `ImageEnlarger`)
 - routine presentation component reuse
 
-## Phase 8: Last 7 Days (2026-07-27 to 2026-08-03)
+#### Phase 8: Last 7 Days (2026-07-27 to 2026-08-03)
 
 Recent commits indicate a concentrated refinement sprint:
 
@@ -124,7 +124,7 @@ Recent commits indicate a concentrated refinement sprint:
 - cleaned docs media/header assets and logo paths
 - removed unused large AskLeida video assets
 
-## What the History Says About Direction
+#### What the History Says About Direction
 
 The overall pattern is not random experimentation. It is structured iteration:
 
@@ -134,7 +134,7 @@ The overall pattern is not random experimentation. It is structured iteration:
 - operational tooling is being tightened
 - docs are maintained as part of delivery
 
-## Where the Repo Is Now
+#### Where the Repo Is Now
 
 The current phase is late-MVP refinement:
 
@@ -143,7 +143,7 @@ The current phase is late-MVP refinement:
 - deployment safety checks are stricter
 - design-system and docs continue to be actively maintained
 
-## Practical Meaning for Handover
+#### Practical Meaning for Handover
 
 Leida is evolving through consolidation rather than replatforming.
 
@@ -155,7 +155,7 @@ That means future work is mostly:
 
 rather than foundational rebuild.
 
-## Read Next
+#### Read Next
 
 - [Executive Overview](../business/executive-overview.md)
 - [Developer Guide](../engineering/developer-guide.md)

--- a/apps/www/public/nx/markdown/docs/concepts/project-evolution.md
+++ b/apps/www/public/nx/markdown/docs/concepts/project-evolution.md
@@ -6,19 +6,6 @@ slug: /docs/concepts/project-evolution
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Project Evolution</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, concepts, project-evolution

--- a/apps/www/public/nx/markdown/docs/engineering/apps-packages.md
+++ b/apps/www/public/nx/markdown/docs/engineering/apps-packages.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/apps-packages
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Apps and Packages</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering, apps-packages

--- a/apps/www/public/nx/markdown/docs/engineering/apps-packages.md
+++ b/apps/www/public/nx/markdown/docs/engineering/apps-packages.md
@@ -14,20 +14,20 @@ NX repository documentation
 
 This monorepo is organized into two main kinds of workspaces: apps and packages.
 
-## Apps
+#### Apps
 Apps are deployable products or experiences. They contain the user-facing application code and are the places where end-to-end features are assembled.
 
 In this repository, the primary app surfaces are [apps/www](../../apps/www) for the public web experience and [apps/admin](../../apps/admin) for internal operations.
 
-## Packages
+#### Packages
 Packages are reusable building blocks shared across apps or internal tooling. They are typically smaller, focused modules that can be imported by multiple parts of the monorepo.
 
 Examples in this repository include shared libraries under [packages](../../packages), such as [packages/design-system](../../packages/design-system), [packages/uberedux](../../packages/uberedux), and utility packages like [packages/firebase](../../packages/firebase).
 
-## How to think about them
+#### How to think about them
 - Use apps for product experiences and deployment targets.
 - Use packages for shared logic, UI, utilities, or integrations.
 - Keep app-specific code in apps and reusable logic in packages.
 
-## Rule of thumb
+#### Rule of thumb
 If something is meant to be used by more than one app, it likely belongs in a package. If it is specific to one product experience, it likely belongs in an app.

--- a/apps/www/public/nx/markdown/docs/engineering/developer-guide.md
+++ b/apps/www/public/nx/markdown/docs/engineering/developer-guide.md
@@ -23,7 +23,7 @@ NX repository documentation
 	</h1>
 </div>
 
-## Purpose
+#### Purpose
 
 This guide is the practical handover for developers building on NX°.
 
@@ -34,7 +34,7 @@ It explains:
 - how apps, packages, and shared runtime layers fit together
 - how to validate changes before shipping
 
-## The 5 Ws for a Developer
+#### The 5 Ws for a Developer
 
 ### What am I looking at?
 
@@ -72,7 +72,7 @@ To keep shared product logic, design systems, and delivery infrastructure reusab
 - cross-app UI primitives: `packages/design-system`
 - shared state and runtime plumbing: `packages/uberedux`
 
-## Repository Map
+#### Repository Map
 
 ### Root
 
@@ -132,7 +132,7 @@ Purpose:
 - app-wide state composition
 - scalable Redux/Uberedux integration
 
-## Architecture Model
+#### Architecture Model
 
 ### NX Runtime
 
@@ -153,7 +153,7 @@ The platform is designed to support multiple product surfaces from one shared co
 - an admin experience for operators and maintainers
 - shared UI and infrastructure to keep both consistent
 
-## Data and API Surfaces
+#### Data and API Surfaces
 
 ### Public APIs
 
@@ -165,14 +165,14 @@ Implemented under `apps/admin/app/api`.
 
 These layers are where integrations, content delivery, and operational endpoints live.
 
-## External Integrations
+#### External Integrations
 
 - Next.js and React
 - Firebase and Supabase-ready patterns
 - Vercel deployment support
 - shared design-system storytelling and Storybook workflows
 
-## Validation and Shipping
+#### Validation and Shipping
 
 Use these checks before shipping meaningful changes:
 
@@ -185,7 +185,7 @@ App-level checks:
 - `pnpm --filter www test`
 - `pnpm --filter admin typecheck`
 
-## Recommended Onboarding Sequence
+#### Recommended Onboarding Sequence
 
 1. Read `docs/README.md`
 2. Read `docs/business/executive-overview.md`
@@ -194,7 +194,7 @@ App-level checks:
 5. Review `apps/www` and `apps/admin`
 6. Explore `packages/design-system`
 
-## First Places to Inspect for Common Tasks
+#### First Places to Inspect for Common Tasks
 
 Public product work:
 
@@ -224,7 +224,7 @@ Shared UI work:
 - `packages/design-system`
 - `packages/ui`
 
-## Read Next
+#### Read Next
 
 - [Operations and Delivery](../business/operations-and-delivery.md)
 - [Project Evolution](../concepts/project-evolution.md)

--- a/apps/www/public/nx/markdown/docs/engineering/developer-guide.md
+++ b/apps/www/public/nx/markdown/docs/engineering/developer-guide.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/developer-guide
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Developer Guide</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering, developer-guide

--- a/apps/www/public/nx/markdown/docs/engineering/developer.md
+++ b/apps/www/public/nx/markdown/docs/engineering/developer.md
@@ -10,7 +10,7 @@ NX repository documentation
 
 > Tags: docs, engineering, developer
 
-## Developer
+#### Developer
 
 As a logged-in GitHub user, go to [github.com/goldlabelapps/nx](https://github.com/goldlabelapps/nx) and click "Use this template."
 

--- a/apps/www/public/nx/markdown/docs/engineering/developer.md
+++ b/apps/www/public/nx/markdown/docs/engineering/developer.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/developer
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Developer</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering, developer

--- a/apps/www/public/nx/markdown/docs/engineering/features/design-system.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/design-system.md
@@ -18,7 +18,7 @@ MUI solves the design system gap for teams that need polished UI out of the box 
 
 NX uses MUI as the foundation for its own theme cartridge, extending the base components with custom styling, utility components, and layout primitives. It gives a consistent look, predictable behaviour, and a reliable way to handle UI complexity without reinventing the basics.
 
-## Design System
+#### Design System
 
 This package is the shared home for presentation-layer work in NX°. It is meant to own the frontend experience beyond a simple color theme, including:
 
@@ -26,20 +26,20 @@ This package is the shared home for presentation-layer work in NX°. It is meant
 - layout primitives for pages and sections
 - shared UI wrappers that can be used across apps and features
 
-## Goals
+#### Goals
 
 - Keep visual decisions centralized in one package
 - Make it easy to build consistent interfaces across the monorepo
 - Provide a lightweight foundation for future component libraries
 
-## Package structure
+#### Package structure
 
 - `src/theme.ts` – theme creation and shared design tokens
 - `src/components/DesignSystemProvider.tsx` – provider that applies the theme and baseline styles
 - `src/components/Primitives.tsx` – layout helpers such as app shells and section wrappers
 - `src/index.ts` – public exports for the package
 
-## Usage
+#### Usage
 
 ```tsx
 import { DesignSystemProvider, AppShell, PageSection, SectionTitle } from '@nx/design-system';
@@ -57,7 +57,7 @@ export default function ExamplePage() {
 }
 ```
 
-## Building
+#### Building
 
 This package ships compiled JavaScript and type declarations to `dist/`.
 
@@ -71,6 +71,6 @@ Notes:
 - The package expects `react`, `react-dom`, and `@mui/material` as peer dependencies.
 - `main`/`types` point to the `dist/` output; add the package to your monorepo's workspace or publish if desired.
 
-## Notes
+#### Notes
 
 This package is intentionally small and composable. As the UI layer grows, new atoms, molecules, and higher-level patterns should be added here instead of being spread across app folders.

--- a/apps/www/public/nx/markdown/docs/engineering/features/design-system.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/design-system.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/features/design-system
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Design System</span>
-    </h1>
-</div>
-
 Material UI
 
 > Tags: docs, engineering, features, design-system

--- a/apps/www/public/nx/markdown/docs/engineering/features/index.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/index.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/features
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Features</span>
-    </h1>
-</div>
-
 Powerful modern technologies
 
 > Tags: docs, engineering, features

--- a/apps/www/public/nx/markdown/docs/engineering/features/pwa.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/pwa.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/features/pwa
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° PWA</span>
-    </h1>
-</div>
-
 Progressive Web Apps
 
 > Tags: docs, engineering, features, pwa

--- a/apps/www/public/nx/markdown/docs/engineering/features/shortcodes.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/shortcodes.md
@@ -26,7 +26,7 @@ By using shortcodes, content creators can
 - Keep markdown files clean and readable
 - Empower non-developers to enhance content without editing code
 
-## Example Usage
+#### Example Usage
 
 Suppose you want to embed a line of chatbot response style text in your markdown, you would do this
 

--- a/apps/www/public/nx/markdown/docs/engineering/features/shortcodes.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/shortcodes.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/features/shortcodes
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Shortcodes</span>
-    </h1>
-</div>
-
 A WordPress concept
 
 > Tags: docs, engineering, features, shortcodes

--- a/apps/www/public/nx/markdown/docs/engineering/features/uberedux.md
+++ b/apps/www/public/nx/markdown/docs/engineering/features/uberedux.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/features/uberedux
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Uberedux</span>
-    </h1>
-</div>
-
 Zero config Redux pattern
 
 > Tags: docs, engineering, features, uberedux

--- a/apps/www/public/nx/markdown/docs/engineering/index.md
+++ b/apps/www/public/nx/markdown/docs/engineering/index.md
@@ -6,19 +6,6 @@ slug: /docs/engineering
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Engineering</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering

--- a/apps/www/public/nx/markdown/docs/engineering/index.md
+++ b/apps/www/public/nx/markdown/docs/engineering/index.md
@@ -21,7 +21,7 @@ This folder contains technical documentation for architecture, implementation, a
 - [Storybook](./storybook.md)
 - [Developer](./developer.md)
 
-## Imported Framework Features
+#### Imported Framework Features
 
 - [Features Overview](./features/features.md)
 - [Design System](./features/design-system.md)
@@ -29,7 +29,7 @@ This folder contains technical documentation for architecture, implementation, a
 - [Shortcodes](./features/shortcodes.md)
 - [Uberedux](./features/uberedux.md)
 
-## Imported Tech Stack Pages
+#### Imported Tech Stack Pages
 
 - [Tech Stack Topic Index](./techstack/techstack.md)
 - [TypeScript](./techstack/typescript.md)

--- a/apps/www/public/nx/markdown/docs/engineering/storybook.md
+++ b/apps/www/public/nx/markdown/docs/engineering/storybook.md
@@ -10,7 +10,7 @@ NX repository documentation
 
 > Tags: docs, engineering, storybook
 
-## Storybook
+#### Storybook
 
 - Start Storybook from the workspace root with `pnpm storybook`.
 - Build the static Storybook bundle from the workspace root with `pnpm build-storybook`.

--- a/apps/www/public/nx/markdown/docs/engineering/storybook.md
+++ b/apps/www/public/nx/markdown/docs/engineering/storybook.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/storybook
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Storybook</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering, storybook

--- a/apps/www/public/nx/markdown/docs/engineering/techstack.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack-overview
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Tech Stack Overview</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering, techstack

--- a/apps/www/public/nx/markdown/docs/engineering/techstack.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack.md
@@ -14,24 +14,24 @@ NX repository documentation
 
 This monorepo uses a modern web stack centered on Next.js, TypeScript, and Turbo.
 
-## Core
+#### Core
 - Node.js and pnpm for package management and workspace orchestration
 - TypeScript for application and shared library code
 - Turbo for monorepo task orchestration and build pipelines
 
-## App Layer
+#### App Layer
 - Next.js for the main web application in apps/nx
 - React and React DOM for UI rendering
 - CSS and component-based styling support for the app experience
 
-## Data and Services
+#### Data and Services
 - Firebase for backend and app services integration
 - Gray-matter and markdown-driven content handling for CMS-style content
 
-## Tooling
+#### Tooling
 - Jest for unit and integration testing
 - ESLint for code quality
 - Vercel deployment configuration for the web app
 
-## Notes
+#### Notes
 - This overview is intentionally concise and easy to update as the stack evolves.

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/fastapi.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/fastapi.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/fastapi
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° FastAPI</span>
-    </h1>
-</div>
-
 High performance and easy-to-use APIs
 
 > Tags: docs, engineering, techstack, fastapi

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/git.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/git.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/git
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Git</span>
-    </h1>
-</div>
-
 Proud to share code
 
 > Tags: docs, engineering, techstack, git

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/index.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/index.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Techstack</span>
-    </h1>
-</div>
-
 Built on Open Source
 
 > Tags: docs, engineering, techstack

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/next-js.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/next-js.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/next-js
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Next.js</span>
-    </h1>
-</div>
-
 Fullstack Node and React
 
 > Tags: docs, engineering, techstack, nextjs

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/python-3.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/python-3.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/python-3
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Python 3</span>
-    </h1>
-</div>
-
 Central to AI and automation
 
 > Tags: docs, engineering, techstack, python-3

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/react.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/react.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/react
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° React</span>
-    </h1>
-</div>
-
 by facebook
 
 > Tags: docs, engineering, techstack, react

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/tsvector.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/tsvector.md
@@ -18,7 +18,7 @@ PostgreSQL provides two data types that are designed to support full text search
 What makes tsvector brilliant is its ability to turn messy, unstructured text into a lightning-fast, searchable format right inside your database. With tsvector, you get powerful, language-aware search capabilities—ranking, stemming, and relevance without leaving Postgres. It’s great for building search features that feel instant and smart.
 
 
-## Full-Text Search
+#### Full-Text Search
 
 The prospects table includes a **search_vector** column computed from all text fields on insert/update. A GIN index enables fast, scalable full-text search:
 

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/tsvector.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/tsvector.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/tsvector
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° tsvector</span>
-    </h1>
-</div>
-
 Superfast full text search
 
 > Tags: docs, engineering, techstack, tsvector

--- a/apps/www/public/nx/markdown/docs/engineering/techstack/typescript.md
+++ b/apps/www/public/nx/markdown/docs/engineering/techstack/typescript.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/techstack/typescript
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° TypeScript</span>
-    </h1>
-</div>
-
 Statically typed superset of JavaScript
 
 > Tags: docs, engineering, techstack, typescript

--- a/apps/www/public/nx/markdown/docs/engineering/testing-strategy.md
+++ b/apps/www/public/nx/markdown/docs/engineering/testing-strategy.md
@@ -6,19 +6,6 @@ slug: /docs/engineering/testing-strategy
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Testing Strategy</span>
-    </h1>
-</div>
-
 NX repository documentation
 
 > Tags: docs, engineering, testing-strategy

--- a/apps/www/public/nx/markdown/docs/engineering/testing-strategy.md
+++ b/apps/www/public/nx/markdown/docs/engineering/testing-strategy.md
@@ -18,7 +18,7 @@ NX° is built with exactly that mindset.
 
 This document explains what we test, why we test it, how those tests run, and what "good" looks like across the monorepo.
 
-## The Pitch
+#### The Pitch
 
 Great testing is not about chasing 100% coverage. It is about reducing expensive surprises.
 
@@ -32,7 +32,7 @@ At NX°, our testing approach is designed to:
 
 When we say quality, we mean: predictable behavior under change.
 
-## What We Test
+#### What We Test
 
 ### 1. Application Unit and Integration Behavior (Jest)
 
@@ -127,7 +127,7 @@ Why it matters:
 - catches CI and local-test breakages caused by script drift
 - keeps testing conventions explicit and enforceable
 
-## How Tests Run Repository-Wide
+#### How Tests Run Repository-Wide
 
 Primary entrypoint:
 
@@ -144,7 +144,7 @@ Current runner implementation:
 
 This gives us one command for full confidence checks across app and package boundaries.
 
-## What Good Looks Like
+#### What Good Looks Like
 
 A healthy testing posture in this repo means:
 
@@ -154,7 +154,7 @@ A healthy testing posture in this repo means:
 - framework guard tests catch accidental test-command regressions
 - root `pnpm test` remains green and fast enough for daily usage
 
-## Why This Is a Competitive Advantage
+#### Why This Is a Competitive Advantage
 
 Teams that test well ship faster over time.
 
@@ -168,7 +168,7 @@ NX° testing discipline gives us:
 
 In short: we do not just "have tests". We have a testing system that protects delivery.
 
-## Command Reference
+#### Command Reference
 
 From repo root:
 
@@ -182,7 +182,7 @@ From repo root:
 - `pnpm --dir packages/virus test` runs virus package tests only
 - `pnpm --dir packages/firebase test` runs firebase package tests only
 
-## Next-Level Enhancements
+#### Next-Level Enhancements
 
 When we want to raise the bar further, highest-value additions are:
 

--- a/apps/www/public/nx/markdown/docs/index.md
+++ b/apps/www/public/nx/markdown/docs/index.md
@@ -6,19 +6,6 @@ slug: /docs
 icon: docs
 tags: docs
 ---
-<div>
-    <h1 style="display: flex; align-items: center; gap: 4px;">
-        <a href="https://goldlabel.pro" target="_blank" rel="noreferrer" style="display: inline-flex; align-items: center;">
-        <img
-            src="https://goldlabel.pro/favicons/favicon_dark.png"
-            width="32"
-            height="32"
-        />
-        </a>
-        <span>NX° Docs</span>
-    </h1>
-</div>
-
 ## NX° Overview
 
 NX° is a modern product platform for building and operating multiple digital experiences from a single, shared codebase. It brings together public-facing apps, admin surfaces, shared UI foundations, and scalable runtime patterns so teams can move faster without sacrificing consistency.

--- a/apps/www/public/nx/markdown/docs/index.md
+++ b/apps/www/public/nx/markdown/docs/index.md
@@ -1,18 +1,18 @@
 ---
 order: 9000
 title: Docs
-description: NX documentation hub
+description: NX° documentation
 slug: /docs
 icon: docs
 tags: docs
 ---
-## NX° Overview
+#### NX° Overview
 
 NX° is a modern product platform for building and operating multiple digital experiences from a single, shared codebase. It brings together public-facing apps, admin surfaces, shared UI foundations, and scalable runtime patterns so teams can move faster without sacrificing consistency.
 
 NX° is built for teams that want a strong foundation for product growth. It is especially useful when you need to support both audience-facing experiences and internal operating tools without fragmenting the codebase.
 
-## Why?
+#### Why?
 
 NX° helps teams:
 
@@ -21,7 +21,7 @@ NX° helps teams:
 - keep customer-facing and internal experiences aligned
 - reduce duplication while preserving flexibility
 
-## What?
+#### What?
 
 - [Executive Overview](/docs/business/executive-overview) for the high-level product story
 - [Developer Guide](/docs/engineering/developer-guide) for the technical structure and onboarding path
@@ -34,7 +34,7 @@ NX° helps teams:
 - [Apps and Packages](/docs/engineering/apps-packages) for the workspace structure
 - [Testing Strategy](/docs/engineering/testing-strategy) for quality assurance, coverage intent, and test execution standards
 
-## Audience
+#### Audience
 
 - [business](/docs/business) for executive, owner, investor, and delivery-facing documentation
 - [engineering](/docs/engineering) for architecture, stack, testing, and developer onboarding docs

--- a/apps/www/public/nx/markdown/experience/index.md
+++ b/apps/www/public/nx/markdown/experience/index.md
@@ -41,7 +41,7 @@ We've been a part of the evolution from the Flash era with basic dial-up experie
 - Key Features: The shift toward serverless architecture and cloud-native development continues. Next.js revolutionizes server-side rendering and static site generation with its App Router. AI tools like OpenAI, TensorFlow.js, and other machine learning libraries are integrated for enhanced features like chatbots, search, and predictive analytics.
 - Development Focus: AI-driven apps (e.g., recommendation engines, chatbots, real-time data analysis) become standard. Serverless computing optimizes infrastructure costs and scalability. The integration of Next.js and TypeScript enhances developer productivity, offering both high performance and a streamlined developer experience.
 
-## Experience Documentation
+#### Experience Documentation
 
 - [Experience concepts hub](/docs/concepts/experience)
 - [AI concepts](/docs/concepts/experience/ai)

--- a/apps/www/public/nx/markdown/features/design-system.md
+++ b/apps/www/public/nx/markdown/features/design-system.md
@@ -15,7 +15,7 @@ MUI solves the design system gap for teams that need polished UI out of the box 
 
 NX uses MUI as the foundation for its own theme cartridge, extending the base components with custom styling, utility components, and layout primitives. It gives a consistent look, predictable behaviour, and a reliable way to handle UI complexity without reinventing the basics.
 
-## Design System
+#### Design System
 
 This package is the shared home for presentation-layer work in NX°. It is meant to own the frontend experience beyond a simple color theme, including:
 
@@ -23,20 +23,20 @@ This package is the shared home for presentation-layer work in NX°. It is meant
 - layout primitives for pages and sections
 - shared UI wrappers that can be used across apps and features
 
-## Goals
+#### Goals
 
 - Keep visual decisions centralized in one package
 - Make it easy to build consistent interfaces across the monorepo
 - Provide a lightweight foundation for future component libraries
 
-## Package structure
+#### Package structure
 
 - `src/theme.ts` – theme creation and shared design tokens
 - `src/components/DesignSystemProvider.tsx` – provider that applies the theme and baseline styles
 - `src/components/Primitives.tsx` – layout helpers such as app shells and section wrappers
 - `src/index.ts` – public exports for the package
 
-## Usage
+#### Usage
 
 ```tsx
 import { DesignSystemProvider, AppShell, PageSection, SectionTitle } from '@nx/design-system';
@@ -54,7 +54,7 @@ export default function ExamplePage() {
 }
 ```
 
-## Building
+#### Building
 
 This package ships compiled JavaScript and type declarations to `dist/`.
 
@@ -68,6 +68,6 @@ Notes:
 - The package expects `react`, `react-dom`, and `@mui/material` as peer dependencies.
 - `main`/`types` point to the `dist/` output; add the package to your monorepo's workspace or publish if desired.
 
-## Notes
+#### Notes
 
 This package is intentionally small and composable. As the UI layer grows, new atoms, molecules, and higher-level patterns should be added here instead of being spread across app folders.

--- a/apps/www/public/nx/markdown/features/index.md
+++ b/apps/www/public/nx/markdown/features/index.md
@@ -9,7 +9,7 @@ tags: features
 
 > [CleverText text="Design System, Uberedux, Shortcodes"]  
 
-## Feature Documentation
+#### Feature Documentation
 
 - [Engineering feature docs](/docs/engineering/features)
 - [Design system docs](/docs/engineering/features/design-system)

--- a/apps/www/public/nx/markdown/features/shortcodes.md
+++ b/apps/www/public/nx/markdown/features/shortcodes.md
@@ -23,7 +23,7 @@ By using shortcodes, content creators can
 - Keep markdown files clean and readable
 - Empower non-developers to enhance content without editing code
 
-## Example Usage
+#### Example Usage
 
 Suppose you want to embed a line of chatbot response style text in your markdown, you would do this
 

--- a/apps/www/public/nx/markdown/index.md
+++ b/apps/www/public/nx/markdown/index.md
@@ -10,12 +10,3 @@ NX° is a powerful framework for rapidly bootstrapping modern apps. Built on mod
 Fast to build, affordable to deploy, and powered by proven web standards—from semantic HTML to static site generation. NX° apps are fast, reliable and make WordPress look very dated
 
 [CleverText text="Ready to create an NX° app?"]
-
-## Extended Documentation
-
-- [Documentation hub](/docs)
-- [Apps docs](/docs/apps)
-- [Concepts docs](/docs/concepts)
-- [Engineering docs](/docs/engineering)
-- [Business docs](/docs/business)
-

--- a/apps/www/public/nx/markdown/techstack/index.md
+++ b/apps/www/public/nx/markdown/techstack/index.md
@@ -9,7 +9,7 @@ tags: Techstack, Vercel, Firebase, Render, React, Python
 
 This project is built on a modern, full-stack foundation: Next.js and React power the frontend, TypeScript keeps the experience reliable, and Python with FastAPI handle the backend and API layer. Git, tsvector, and a lightweight cloud setup round out a stack that is fast, flexible, and ready to scale.
 
-## Techstack Documentation
+#### Techstack Documentation
 
 - [Engineering techstack hub](/docs/engineering/techstack)
 - [Concepts techstack notes](/docs/concepts/experience/techstack)

--- a/apps/www/public/nx/markdown/techstack/tsvector.md
+++ b/apps/www/public/nx/markdown/techstack/tsvector.md
@@ -16,7 +16,7 @@ PostgreSQL provides two data types that are designed to support full text search
 What makes tsvector brilliant is its ability to turn messy, unstructured text into a lightning-fast, searchable format right inside your database. With tsvector, you get powerful, language-aware search capabilities—ranking, stemming, and relevance without leaving Postgres. It’s great for building search features that feel instant and smart.
 
 
-## Full-Text Search
+#### Full-Text Search
 
 The prospects table includes a **search_vector** column computed from all text fields on insert/update. A GIN index enables fast, scalable full-text search:
 


### PR DESCRIPTION
Clean up the markdown docs by deleting the repeated inline HTML title/logo blocks from each page. This leaves the frontmatter and page content as the source of truth for headings, and also removes the stray `description: <div>` value from the app docs index.